### PR TITLE
Constify some strings

### DIFF
--- a/doc/stylesheets/cli.xsl
+++ b/doc/stylesheets/cli.xsl
@@ -19,7 +19,7 @@ typedef struct {
 	const char *value;
 } Argument;
 
-typedef int (*option_handler_t)(Tracee *tracee, char *value);
+typedef int (*option_handler_t)(Tracee *tracee, const char *value);
 
 typedef struct {
 	const char *class;
@@ -171,7 +171,7 @@ static Option options[] = {
   <xsl:template match="option_group" mode="handlers">
     <xsl:text>static int handle_option_</xsl:text>
     <xsl:value-of select="substring(option[1]/option_string, 2, 1)" />
-    <xsl:text>(Tracee *tracee, char *value);
+    <xsl:text>(Tracee *tracee, const char *value);
 </xsl:text>
   </xsl:template>
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -13,7 +13,7 @@ typedef struct {
 	const char *value;
 } Argument;
 
-typedef int (*option_handler_t)(Tracee *tracee, char *value);
+typedef int (*option_handler_t)(Tracee *tracee, const char *value);
 
 typedef struct {
 	const char *class;
@@ -58,18 +58,18 @@ static char *recommended_bindings[] = {
 	NULL,
 };
 
-static int handle_option_r(Tracee *tracee, char *value);
-static int handle_option_b(Tracee *tracee, char *value);
-static int handle_option_q(Tracee *tracee, char *value);
-static int handle_option_w(Tracee *tracee, char *value);
-static int handle_option_v(Tracee *tracee, char *value);
-static int handle_option_V(Tracee *tracee, char *value);
-static int handle_option_h(Tracee *tracee, char *value);
-static int handle_option_k(Tracee *tracee, char *value);
-static int handle_option_0(Tracee *tracee, char *value);
-static int handle_option_R(Tracee *tracee, char *value);
-static int handle_option_B(Tracee *tracee, char *value);
-static int handle_option_Q(Tracee *tracee, char *value);
+static int handle_option_r(Tracee *tracee, const char *value);
+static int handle_option_b(Tracee *tracee, const char *value);
+static int handle_option_q(Tracee *tracee, const char *value);
+static int handle_option_w(Tracee *tracee, const char *value);
+static int handle_option_v(Tracee *tracee, const char *value);
+static int handle_option_V(Tracee *tracee, const char *value);
+static int handle_option_h(Tracee *tracee, const char *value);
+static int handle_option_k(Tracee *tracee, const char *value);
+static int handle_option_0(Tracee *tracee, const char *value);
+static int handle_option_R(Tracee *tracee, const char *value);
+static int handle_option_B(Tracee *tracee, const char *value);
+static int handle_option_Q(Tracee *tracee, const char *value);
 
 static Option options[] = {
 	{ .class = "Regular options",

--- a/src/execve/execve.c
+++ b/src/execve/execve.c
@@ -174,7 +174,7 @@ static int handle_sub_reconf(Tracee *tracee, Array *argv, const char *host_path)
 	static char *self_exe = NULL;
 	Tracee *dummy = NULL;
 	char path[PATH_MAX];
-	char **argv_pod;
+	const char **argv_pod;
 	int status;
 	size_t i;
 
@@ -327,7 +327,7 @@ int translate_execve(Tracee *tracee)
 
 	Array *envp = NULL;
 	Array *argv = NULL;
-	char *argv0 = NULL;
+	const char *argv0 = NULL;
 
 	char **new_cmdline;
 	char *new_exe;
@@ -397,13 +397,13 @@ int translate_execve(Tracee *tracee)
 		return -ENOMEM;
 
 	for (i = 0; i < argv->length; i++) {
-		char *ptr;
+		const char *ptr;
 		status = read_item_string(argv, i, &ptr);
 		if (status < 0)
 			return status;
 		/* It's safe to reference these strings since they are never
 		 * overwritten, they are just replaced.  */
-		new_cmdline[i] = talloc_reference(new_cmdline, ptr);
+		new_cmdline[i] = talloc_reference(new_cmdline, (char *)ptr);
 	}
 
 	if (tracee->qemu != NULL) {

--- a/src/execve/ldso.c
+++ b/src/execve/ldso.c
@@ -56,7 +56,7 @@ static inline bool is_env_name(const char *variable, const char *name)
  */
 int compare_item_env(Array *array, size_t index, const char *reference)
 {
-	char *value;
+	const char *value;
 	int status;
 
 	assert(index < array->length);
@@ -107,7 +107,7 @@ int ldso_env_passthru(const Tracee *tracee, Array *envp, Array *argv,
 
 	for (i = 0; i < envp->length; i++) {
 		bool is_known = false;
-		char *env;
+		const char *env;
 
 		status = read_item_string(envp, i, &env);
 		if (status < 0)
@@ -328,7 +328,7 @@ int rebuild_host_ldso_paths(Tracee *tracee, const char t_program[PATH_MAX], Arra
 		/* Remember guest LD_LIBRARY_PATH in order to restore
 		 * it when a host program will execute a guest
 		 * program.  */
-		char *env;
+		const char *env;
 
 		/* Errors are not fatal here.  */
 		status = read_item_string(envp, index, &env);

--- a/src/tracee/array.c
+++ b/src/tracee/array.c
@@ -53,7 +53,7 @@ struct array_entry {
  * @array at the given @index.  This function returns -errno when an
  * error occured, otherwise 0.
  */
-int read_item_data(Array *array, size_t index, void **value)
+int read_item_data(Array *array, size_t index, const void **value)
 {
 	int status;
 	int size;
@@ -96,7 +96,7 @@ end:
  * @array at the given @index.  This function returns -errno when an
  * error occured, otherwise 0.
  */
-int read_item_string(Array *array, size_t index, char **value)
+int read_item_string(Array *array, size_t index, const char **value)
 {
 	char tmp[ARG_MAX];
 	int status;
@@ -137,7 +137,7 @@ end:
  */
 int sizeof_item_string(Array *array, size_t index)
 {
-	char *value;
+	const char *value;
 	int status;
 
 	assert(index < array->length);

--- a/src/tracee/array.h
+++ b/src/tracee/array.h
@@ -70,8 +70,8 @@ extern int resize_array(Array *array, size_t index, ssize_t nb_delta_entries);
 extern int fetch_array(Tracee *tracee, Array **array, Reg reg, size_t nb_entries);
 extern int push_array(Array *array, Reg reg);
 
-extern int read_item_data(Array *array, size_t index, void **value);
-extern int read_item_string(Array *array, size_t index, char **value);
+extern int read_item_data(Array *array, size_t index, const void **value);
+extern int read_item_string(Array *array, size_t index, const char **value);
 extern int write_item_string(Array *array, size_t index, const char *value);
 extern int write_items(Array *array, size_t index, size_t nb_items, ...);
 extern int compare_item_generic(Array *array, size_t index, const void *reference);

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -181,7 +181,7 @@ typedef struct tracee {
 extern Tracee *get_tracee(const Tracee *tracee, pid_t pid, bool create);
 extern int new_child(Tracee *parent, word_t clone_flags);
 extern int swap_config(Tracee *tracee1, Tracee *tracee2);
-extern int parse_config(Tracee *tracee, size_t argc, char *argv[]);
+extern int parse_config(Tracee *tracee, size_t argc, const char *argv[]);
 extern void kill_all_tracees();
 
 #endif /* TRACEE_H */


### PR DESCRIPTION
Add a const to the last argument of read_item_string and fix the warnings that appears.

Maybe some more work can be done to also constify tracee->cmdline.
