### PR TITLE
Warn extensions if fd exists when launching the application

### DIFF
--- a/src/extension/extension.h
+++ b/src/extension/extension.h
@@ -111,6 +111,10 @@ typedef enum {
 	/* Print the usage of the extension: "(bool) data1" is true
 	 * for a detailed usage.  See print_usage() as an example.  */
 	PRINT_USAGE,
+
+	/* Called for every already opened file descriptor:
+	 * "(const char *) data1" is the path, "(int) data2" is the file descriptor */
+	ALREADY_OPENED_FD,
 } ExtensionEvent;
 
 struct extension;

--- a/src/path/path.c
+++ b/src/path/path.c
@@ -697,6 +697,7 @@ int list_open_fd(const Tracee *tracee)
 		VERBOSE(tracee, 1,
 			"pid %d: access to \"%s\" (fd %d) won't be translated until closed",
 			tracee->pid, path, fd);
+		notify_extensions((Tracee *)tracee, ALREADY_OPENED_FD, (intptr_t)path, (intptr_t)fd);
 		return 0;
 	}
 	return foreach_fd(tracee, list_open_fd_callback);

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -62,6 +62,10 @@ int launch_process(Tracee *tracee)
 	long status;
 	pid_t pid;
 
+	/* Warn about open file descriptors. They won't be
+	 * translated until they are closed. */
+	list_open_fd(tracee);
+
 	pid = fork();
 	switch(pid) {
 	case -1:
@@ -76,10 +80,6 @@ int launch_process(Tracee *tracee)
 			notice(tracee, ERROR, SYSTEM, "ptrace(TRACEME)");
 			return -errno;
 		}
-
-		/* Warn about open file descriptors. They won't be
-		 * translated until they are closed. */
-		list_open_fd(tracee);
 
 		/* RHEL4 uses an ASLR mechanism that creates conflicts
 		 * between the layout of QEMU and the layout of the

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -79,8 +79,7 @@ int launch_process(Tracee *tracee)
 
 		/* Warn about open file descriptors. They won't be
 		 * translated until they are closed. */
-		if (tracee->verbose > 0)
-			list_open_fd(tracee);
+		list_open_fd(tracee);
 
 		/* RHEL4 uses an ASLR mechanism that creates conflicts
 		 * between the layout of QEMU and the layout of the


### PR DESCRIPTION
This is useful to track stdin, stdout and stderr file descriptors.
Ad written in the header, the arguments are:
- (const char *) data1: the path to the file
- (int) data2: the open file descriptor
