### PR TITLE
fake_id0: improve (r|e|s)(u|g)id support

### DIFF
--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -24,9 +24,11 @@
 #include <stdint.h>  /* intptr_t, */
 #include <errno.h>   /* E*, */
 #include <sys/stat.h>   /* chmod(2), stat(2) */
+#include <sys/types.h>  /* uid_t, gid_t */
 #include <unistd.h>  /* get*id(2),  */
 #include <sys/ptrace.h>    /* linux.git:c0a3a20b  */
 #include <linux/audit.h>   /* AUDIT_ARCH_*,  */
+#include <string.h>  /* memcpy(3) */
 
 #include "extension/extension.h"
 #include "syscall/syscall.h"
@@ -37,6 +39,16 @@
 #include "tracee/mem.h"
 #include "path/binding.h"
 #include "arch.h"
+
+typedef struct {
+	uid_t ruid;
+	uid_t euid;
+	uid_t suid;
+
+	gid_t rgid;
+	gid_t egid;
+	gid_t sgid;
+} Config;
 
 typedef struct {
 	char *path;
@@ -99,6 +111,10 @@ static FilteredSysnum filtered_sysnums[] = {
 	{ PR_setgid32,		FILTER_SYSEXIT },
 	{ PR_setgroups,		FILTER_SYSEXIT },
 	{ PR_setgroups32,	FILTER_SYSEXIT },
+	{ PR_setregid,		FILTER_SYSEXIT },
+	{ PR_setregid32,	FILTER_SYSEXIT },
+	{ PR_setreuid,		FILTER_SYSEXIT },
+	{ PR_setreuid32,	FILTER_SYSEXIT },
 	{ PR_setresgid,		FILTER_SYSEXIT },
 	{ PR_setresgid32,	FILTER_SYSEXIT },
 	{ PR_setresuid,		FILTER_SYSEXIT },
@@ -200,11 +216,36 @@ static void handle_host_path(const Tracee *tracee, const char *path, bool is_fin
 	return;
 }
 
+
+/**
+ * Set @field to @value, iif @value is not -1
+ */
+#define SET_ID(field, sysarg)														\
+	do {																									\
+		word_t value = peek_reg(tracee, ORIGINAL, sysarg);	\
+		if (value != (word_t)-1)														\
+			config->field = value;														\
+	} while (0)
+
+
+#define OVERRIDE_EPERM_AND_FORCE()											\
+	do {																									\
+		word_t result;																			\
+		/* Override only permission errors.  */							\
+		result = peek_reg(tracee, CURRENT, SYSARG_RESULT);	\
+		if ((int) result != -EPERM)													\
+			return 0;																					\
+																												\
+		/* Force success.  */																\
+		poke_reg(tracee, SYSARG_RESULT, 0);									\
+	} while (0)
+
+
 /**
  * Force current @tracee's syscall to behave as if executed by "root".
  * This function returns -errno if an error occured, otherwise 0.
  */
-static int handle_sysexit_end(Tracee *tracee)
+static int handle_sysexit_end(Tracee *tracee, Config *config)
 {
 	word_t sysnum;
 
@@ -237,10 +278,64 @@ static int handle_sysexit_end(Tracee *tracee)
 		return 0;
 	}
 
+	case PR_setregid:
+	case PR_setregid32:
+		OVERRIDE_EPERM_AND_FORCE();
+		SET_ID(rgid, SYSARG_1);
+		SET_ID(egid, SYSARG_2);
+		return 0;
+
+	case PR_setreuid:
+	case PR_setreuid32:
+		OVERRIDE_EPERM_AND_FORCE();
+		SET_ID(rgid, SYSARG_1);
+		SET_ID(egid, SYSARG_2);
+		return 0;
+
 	case PR_setresuid:
-	case PR_setresgid:
 	case PR_setresuid32:
+		OVERRIDE_EPERM_AND_FORCE();
+		SET_ID(ruid, SYSARG_1);
+		SET_ID(euid, SYSARG_2);
+		SET_ID(suid, SYSARG_3);
+		return 0;
+
+	case PR_setresgid:
 	case PR_setresgid32:
+		OVERRIDE_EPERM_AND_FORCE();
+		SET_ID(rgid, SYSARG_1);
+		SET_ID(egid, SYSARG_2);
+		SET_ID(sgid, SYSARG_3);
+		return 0;
+
+	case PR_setuid:
+	case PR_setuid32: {
+		OVERRIDE_EPERM_AND_FORCE();
+		uid_t new_uid = peek_reg(tracee, ORIGINAL, SYSARG_1);
+		if (config->euid == 0) {
+			config->ruid = new_uid;
+			config->suid = new_uid;
+		}
+		config->euid = new_uid;
+
+		return 0;
+	}
+
+	case PR_setgid:
+	case PR_setgid32: {
+		OVERRIDE_EPERM_AND_FORCE();
+		gid_t new_gid = peek_reg(tracee, ORIGINAL, SYSARG_1);
+		if (config->egid == 0) {
+			config->rgid = config->egid;
+			config->sgid = config->egid;
+		}
+		config->egid = new_gid;
+
+		return 0;
+	}
+
+	case PR_setgroups:
+	case PR_setgroups32:
 	case PR_mknod:
 	case PR_capset:
 	case PR_setxattr:
@@ -253,32 +348,39 @@ static int handle_sysexit_end(Tracee *tracee)
 	case PR_fchown32:
 	case PR_lchown32:
 	case PR_fchmodat:
-	case PR_fchownat: {
-		word_t result;
+	case PR_fchownat:
+		OVERRIDE_EPERM_AND_FORCE();
+		return 0;
 
-		/* Override only permission errors.  */
-		result = peek_reg(tracee, CURRENT, SYSARG_RESULT);
-		if ((int) result != -EPERM)
-			return 0;
+	case PR_getresuid:
+	case PR_getresuid32:
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_1), config->ruid);
+		if (errno != 0)
+			return -EFAULT;
+
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_2), config->euid);
+		if (errno != 0)
+			return -EFAULT;
+
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_3), config->suid);
+		if (errno != 0)
+			return -EFAULT;
 
 		/* Force success.  */
 		poke_reg(tracee, SYSARG_RESULT, 0);
 		return 0;
-	}
 
-	case PR_getresuid:
-	case PR_getresuid32:
 	case PR_getresgid:
 	case PR_getresgid32:
-		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_1), 0);
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_1), config->rgid);
 		if (errno != 0)
 			return -EFAULT;
 
-		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_2), 0);
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_2), config->egid);
 		if (errno != 0)
 			return -EFAULT;
 
-		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_3), 0);
+		poke_mem(tracee, peek_reg(tracee, ORIGINAL, SYSARG_3), config->sgid);
 		if (errno != 0)
 			return -EFAULT;
 
@@ -335,22 +437,28 @@ static int handle_sysexit_end(Tracee *tracee)
 		return 0;
 	}
 
-	case PR_getuid:
-	case PR_getgid:
-	case PR_getegid:
-	case PR_geteuid:
 	case PR_getuid32:
+	case PR_getuid:
+		poke_reg(tracee, SYSARG_RESULT, config->ruid);
+		return 0;
+
 	case PR_getgid32:
+	case PR_getgid:
+		poke_reg(tracee, SYSARG_RESULT, config->rgid);
+		return 0;
+
 	case PR_geteuid32:
+	case PR_geteuid:
+		poke_reg(tracee, SYSARG_RESULT, config->euid);
+		return 0;
+
 	case PR_getegid32:
-	case PR_setuid:
-	case PR_setgid:
-	case PR_setgroups:
-	case PR_setgroups32:
+	case PR_getegid:
+		poke_reg(tracee, SYSARG_RESULT, config->egid);
+		return 0;
+
 	case PR_setfsuid:
 	case PR_setfsgid:
-	case PR_setuid32:
-	case PR_setgid32:
 	case PR_setfsuid32:
 	case PR_setfsgid32:
 		/* Force success.  */
@@ -362,6 +470,10 @@ static int handle_sysexit_end(Tracee *tracee)
 	}
 }
 
+#undef OVERRIDE_EPERM_AND_FORCE
+#undef SET_ID
+
+
 /**
  * Handler for this @extension.  It is triggered each time an @event
  * occurred.  See ExtensionEvent for the meaning of @data1 and @data2.
@@ -369,22 +481,43 @@ static int handle_sysexit_end(Tracee *tracee)
 int fake_id0_callback(Extension *extension, ExtensionEvent event, intptr_t data1, intptr_t data2)
 {
 	switch (event) {
-	case INITIALIZATION:
+	case INITIALIZATION: {
+		/* Set all uid and gid to 0  */
+		extension->config = talloc_zero(extension, Config);
+		if (extension->config == NULL)
+			return -1;
+
 		extension->filtered_sysnums = filtered_sysnums;
 		return 0;
+	}
 
 	case INHERIT_PARENT: /* Inheritable for sub reconfiguration ...  */
 		return 1;
 
-	case INHERIT_CHILD:  /* ... but there's nothing else to do.  */
+	case INHERIT_CHILD: {
+		/* Copy the parent configuration to the child. The structure should not be
+		 * shared as uid/gid changes in one process should not affect the second
+		 * process.  */
+
+		Extension *parent = (Extension *)data1;
+		extension->config = talloc_zero(extension, Config);
+		if (extension->config == NULL)
+			return -1;
+
+		memcpy(extension->config, parent->config, sizeof(Config));
 		return 0;
+	}
 
 	case HOST_PATH:
 		handle_host_path(TRACEE(extension), (char*) data1, (bool) data2);
 		return 0;
 
-	case SYSCALL_EXIT_END:
-		return handle_sysexit_end(TRACEE(extension));
+	case SYSCALL_EXIT_END: {
+		Tracee *tracee = TRACEE(extension);
+		Config *config = talloc_get_type_abort(extension->config, Config);
+
+		return handle_sysexit_end(tracee, config);
+	}
 
 	default:
 		return 0;


### PR DESCRIPTION
The extension is now tracking (real, effective and saved) user and group ids.

This commit allows to run samba4 configure succefully:

Before
  $ proot -w samba-4.1.0 -0 /bin/sh configure
  [...]
  Checking whether Linux should use 32-bit credential calls                                       : not found
  Checking whether we can use Linux thread-specific credentials                                   : not found
  [...]
  Checking whether setuidx is available : samba-4.1.0/source3/wscript:997: error: the configuration failed (see 'samba-4.1.0/bin/config.log')

After
  $ proot -w samba-4.1.0 -0 /bin/sh configure
  [...]
  Checking whether Linux should use 32-bit credential calls                                       : not found
  Checking whether we can use Linux thread-specific credentials                                   : ok
  [...]
  'configure' finished successfully
