### PR TITLE
Fix use of size

### DIFF
--- a/src/execve/enter.c
+++ b/src/execve/enter.c
@@ -460,10 +460,10 @@ static int expand_runner(Tracee* tracee, char host_path[PATH_MAX], char user_pat
 }
 
 extern unsigned char _binary_loader_exe_start;
-extern unsigned char _binary_loader_exe_size;
+extern unsigned char _binary_loader_exe_end;
 
 extern unsigned char WEAK _binary_loader_m32_exe_start;
-extern unsigned char WEAK _binary_loader_m32_exe_size;
+extern unsigned char WEAK _binary_loader_m32_exe_end;
 
 /**
  * Extract the built-in loader.  This function returns NULL if an
@@ -489,11 +489,11 @@ static char *extract_loader(const Tracee *tracee, bool wants_32bit_version)
 
 	if (wants_32bit_version) {
 		start = (void *) &_binary_loader_m32_exe_start;
-		size  = (size_t) &_binary_loader_m32_exe_size;
+		size  = (size_t)(&_binary_loader_m32_exe_end-&_binary_loader_m32_exe_start);
 	}
 	else {
 		start = (void *) &_binary_loader_exe_start;
-		size  = (size_t) &_binary_loader_exe_size;
+		size  = (size_t) (&_binary_loader_exe_end-&_binary_loader_exe_start);
 	}
 
 	status2 = write(fd, start, size);


### PR DESCRIPTION
Not correct:
size  = (size_t) &_binary_loader_m32_exe_size;

size  = (size_t) _binary_loader_m32_exe_size;
Should be correct maybe? Don't know. So I do : 
size  = (size_t)(&_binary_loader_m32_exe_end-&_binary_loader_m32_exe_start);

Without this patch we got:
$ proot -v 10 ls
proot info: binding = /
proot info: vpid 1: translate("/home/alkino" + "ls")
proot info: vpid 1:          -> "/home/alkino/ls"
proot info: vpid 1: translate("/" + "/usr/lib/hardening-wrapper/bin/ls")
proot info: vpid 1:          -> "/usr/lib/hardening-wrapper/bin/ls"
proot info: vpid 1: translate("/" + "/usr/local/sbin/ls")
proot info: vpid 1:          -> "/usr/local/sbin/ls"
proot info: vpid 1: translate("/" + "/usr/local/bin/ls")
proot info: vpid 1:          -> "/usr/local/bin/ls"
proot info: vpid 1: translate("/" + "/usr/bin/ls")
proot info: vpid 1:          -> "/usr/bin/ls"
proot info: vpid 1: translate("/" + "/usr/bin/ls")
proot info: vpid 1:          -> "/usr/bin/ls"
proot info: exe = /usr/bin/ls
proot info: argv = ls
proot info: initial cwd = /home/alkino
proot info: verbose level = 1000
proot info: pid 26839: access to "/dev/pts/5" (fd 0) won't be translated until closed
proot info: pid 26839: access to "/dev/pts/5" (fd 1) won't be translated until closed
proot info: pid 26839: access to "/dev/pts/5" (fd 2) won't be translated until closed
proot info: pid 26839: access to "/proc/26839/fd" (fd 3) won't be translated until closed
proot info: pid 26839: access to "/tmp/wmfs-:0.log" (fd 4) won't be translated until closed
proot info: vpid 1: sysenter start: prctl(0x26, 0x1, 0x0, 0x0, 0x0, 0x1d140) = 0xffffffffffffffda [0x7ffd15143d98, 0]
proot info: vpid 1: sysenter end: prctl(0x26, 0x1, 0x0, 0x0, 0x0, 0x1d140) = 0xffffffffffffffda [0x7ffd15143d98, 0]
proot info: vpid 1: sysexit start: prctl(0x26, 0x1, 0x0, 0x0, 0x0, 0x1d140) = 0x0 [0x7ffd15143d98, 0]
proot info: vpid 1: sysexit end: prctl(0x26, 0x1, 0x0, 0x0, 0x0, 0x1d140) = 0x0 [0x7ffd15143d98, 0]
proot info: vpid 1: sysenter start: prctl(0x16, 0x2, 0x7ffd15143df0, 0x7f40ae53746a, 0x0, 0x1d140) = 0xffffffffffffffda [0x7ffd15143d98, 0]
proot info: vpid 1: sysenter end: prctl(0x16, 0x2, 0x7ffd15143df0, 0x7f40ae53746a, 0x0, 0x1d140) = 0xffffffffffffffda [0x7ffd15143d98, 0]
proot info: vpid 1: sysexit start: prctl(0x16, 0x2, 0x7ffd15143df0, 0x7f40ae53746a, 0x0, 0x1d140) = 0x0 [0x7ffd15143d98, 0]
proot info: vpid 1: sysexit end: prctl(0x16, 0x2, 0x7ffd15143df0, 0x7f40ae53746a, 0x0, 0x1d140) = 0x0 [0x7ffd15143d98, 0]
proot info: ptrace acceleration (seccomp mode 2) enabled
proot info: vpid 1: sysenter start: execve(0x558776ad1b70, 0x7ffd15144070, 0x7ffd15144080, 0x5a7, 0x7f40ae7ebb78, 0x1d140) = 0xffffffffffffffda [0x7ffd15143e38, 0]
proot info: vpid 1: translate("/" + "/usr/bin/ls")
proot info: vpid 1:          -> "/usr/bin/ls"
proot info: vpid 1: translate("/" + "/lib64/ld-linux-x86-64.so.2")
proot info: vpid 1:          -> "/usr/lib/ld-2.21.so"
proot error: can't write the loader: Bad address
proot info: vpid 1: sysenter end: void(0x558776ad1b70, 0x7ffd15144070, 0x7ffd15144080, 0x5a7, 0x7f40ae7ebb78, 0x1d140) = 0xfffffffffffffffe [0x7ffd15143e38, 0]
proot info: vpid 1: sysexit start: void(0x558776ad1b70, 0x7ffd15144070, 0x7ffd15144080, 0x5a7, 0x7f40ae7ebb78, 0x1d140) = 0xfffffffffffffffe [0x7ffd15143e38, 0]
proot info: vpid 1: sysexit end: execve(0x558776ad1b70, 0x7ffd15144070, 0x7ffd15144080, 0x5a7, 0x7f40ae7ebb78, 0x1d140) = 0xfffffffffffffffe [0x7ffd15143e38, 0]
proot error: execve("/usr/bin/ls"): No such file or directory
proot info: possible causes:
- the program is a script but its interpreter (eg. /bin/sh) was not found;
- the program is an ELF but its interpreter (eg. ld-linux.so) was not found;
- the program is a foreign binary but qemu was not specified;
- qemu does not work correctly (if specified);
- the loader was not found or doesn't work.
  fatal error: see `proot --help`.
  proot info: vpid 1: exited with status 1
