### PR TITLE
canon: call bindings substitution on '/' component of user path

### DIFF
--- a/src/path/canon.c
+++ b/src/path/canon.c
@@ -186,6 +186,7 @@ int canonicalize(Tracee *tracee, const char *user_path, bool deref_final,
 		 char guest_path[PATH_MAX], unsigned int recursion_level)
 {
 	char scratch_path[PATH_MAX];
+	char host_path[PATH_MAX];
 	Finality finality;
 	const char *cursor;
 	int status;
@@ -211,13 +212,20 @@ int canonicalize(Tracee *tracee, const char *user_path, bool deref_final,
 	else
 		strcpy(guest_path, "/");
 
+
+	/* Resolve bindings for the initial '/' component or user_path,
+	 * which is not handled in the loop below.
+	 * In particular HOST_PATH extensions are called from there.  */
+	status = substitute_binding_stat(tracee, NOT_FINAL, recursion_level, guest_path, host_path);
+	if (status < 0)
+		return status;
+
 	/* Canonicalize recursely 'user_path' into 'guest_path'.  */
 	cursor = user_path;
 	finality = NOT_FINAL;
 	while (!IS_FINAL(finality)) {
 		Comparison comparison;
 		char component[NAME_MAX];
-		char host_path[PATH_MAX];
 
 		finality = next_component(component, &cursor);
 		status = (int) finality;


### PR DESCRIPTION
Force binding substitution and invocation of HOST_PATH extensions
on the first component of a user path (i.e. '/').

Otherwise for instance the following does not work when the rootfs
is readonly with fake_id0 extension:
$ proot -O -r rootfs touch /empty

This change will scan both '/' and 'empty' path components when
the '/empty' path is canonicalized, formerly, only the 'empty'
component was scanned.
