### PR TITLE
Fix loader extraction.

### DIFF
--- a/src/execve/enter.c
+++ b/src/execve/enter.c
@@ -454,10 +454,10 @@ static int expand_runner(Tracee* tracee, char host_path[PATH_MAX], char user_pat
 }
 
 extern unsigned char _binary_loader_exe_start;
-extern unsigned char _binary_loader_exe_size;
+extern unsigned char _binary_loader_exe_end;
 
 extern unsigned char WEAK _binary_loader_m32_exe_start;
-extern unsigned char WEAK _binary_loader_m32_exe_size;
+extern unsigned char WEAK _binary_loader_m32_exe_end;
 
 /**
  * Extract the built-in loader.  This function returns NULL if an
@@ -481,14 +481,14 @@ static char *extract_loader(const Tracee *tracee, bool wants_32bit_version)
 		goto end;
 	fd = fileno(file);
 
-	if (wants_32bit_version) {
-		start = (void *) &_binary_loader_m32_exe_start;
-		size  = (size_t) &_binary_loader_m32_exe_size;
-	}
-	else {
-		start = (void *) &_binary_loader_exe_start;
-		size  = (size_t) &_binary_loader_exe_size;
-	}
+        if (wants_32bit_version) {
+                start = (void *) &_binary_loader_m32_exe_start;
+                size = &_binary_loader_m32_exe_end - &_binary_loader_m32_exe_start;
+        }
+        else {
+                start = (void *) &_binary_loader_exe_start;
+                size = &_binary_loader_exe_end - &_binary_loader_exe_start;
+        }
 
 	status2 = write(fd, start, size);
 	if (status2 != size) {


### PR DESCRIPTION
Fixes this: 
```
➜  src git:(master) ✗ ./proot ls
proot error: can't write the loader: Bad address
proot error: execve("/bin/ls"): No such file or directory
proot info: possible causes:
  * the program is a script but its interpreter (eg. /bin/sh) was not found;
  * the program is an ELF but its interpreter (eg. ld-linux.so) was not found;
  * the program is a foreign binary but qemu was not specified;
  * qemu does not work correctly (if specified);
  * the loader was not found or doesn't work.
fatal error: see `proot --help`.
```

- Tested on kernel >= 4.8
- Doesn't harm older kernels