### PR TITLE
Support for musl libc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,8 @@
+This fork
+=========
+
+Making proot work with musl libc
+
 Manuals
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,3 @@
-This fork
-=========
-
-Making proot work with musl libc
-
 Manuals
 =======
 

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -143,8 +143,8 @@ LINK    = $($(quiet)LD) -o $@ $^ $(LDFLAGS)
 
 OBJIFY = $($(quiet)GEN)									\
 	$(OBJCOPY)									\
-		--input binary								\
-		--output `env LC_ALL=C $(OBJDUMP) -f cli/cli.o |			\
+		--input-target binary							\
+		--output-target `env LC_ALL=C $(OBJDUMP) -f cli/cli.o |			\
 			grep 'file format' | awk '{print $$4}'`				\
 		--binary-architecture `env LC_ALL=C $(OBJDUMP) -f cli/cli.o |		\
 				grep architecture | cut -f 1 -d , | awk '{print $$2}'`	\

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -30,8 +30,12 @@
 #include <sys/types.h>     /* getpid(2),  */
 #include <unistd.h>        /* getpid(2),  */
 #include <errno.h>         /* errno(3), */
-#include <execinfo.h>      /* backtrace_symbols(3), */
 #include <limits.h>        /* INT_MAX, */
+
+/* execinfo.h is GNU extension, disable it not using glibc */
+#if defined(__GLIBC__)
+#include <execinfo.h>      /* backtrace_symbols(3), */
+#endif
 
 #include "cli/cli.h"
 #include "cli/note.h"
@@ -550,6 +554,9 @@ const char *expand_front_variable(TALLOC_CTX *context, const char *string)
  * with CFLAGS='-finstrument-functions -O0 -g' and LDFLAGS='-rdynamic'
  * to enable this mechanism.  */
 
+/* since we rely on GLIBC extensions, disable all of this code if
+ * __GLIBC__ is not defined */
+#if defined(__GLIBC__)
 static int indent_level = 0;
 
 void __cyg_profile_func_enter(void *this_function, void *call_site) DONT_INSTRUMENT;
@@ -578,3 +585,4 @@ void __cyg_profile_func_exit(void *this_function UNUSED, void *call_site UNUSED)
 	if (indent_level > 0)
 		indent_level--;
 }
+#endif

--- a/src/extension/portmap/portmap.c
+++ b/src/extension/portmap/portmap.c
@@ -4,11 +4,11 @@
 
 #include <stdint.h>         /* intptr_t, */
 #include <stdlib.h>         /* strtoul(3), */
+#include <string.h>			/* memset */
 #include <sys/un.h>         /* strncpy */
 #include <sys/socket.h>	    /* AF_UNIX, AF_INET */
 #include <arpa/inet.h>      /* inet_ntop */
 #include <linux/net.h>   	/* SYS_*, */
-
 #include "cli/note.h"
 #include "extension/extension.h"
 #include "tracee/mem.h"     /* read_data */
@@ -107,7 +107,7 @@ int prepare_getsockname_chained_syscall(Tracee *tracee, Config *config, word_t s
 	if(size_addr == 0)
 		return -EFAULT;
 
-	bzero(&sockaddr, sizeof(sockaddr));
+	memset(&sockaddr, '\0', sizeof(sockaddr));
 
 	/* we write the modified socket in this new address */
 	status = write_data(tracee, sock_addr, &sockaddr, sizeof(sockaddr));
@@ -170,7 +170,7 @@ int translate_port(Tracee *tracee, Config *config, word_t sockfd, word_t *sock_a
 		return 0;
 		
 	/* Essential step, we clean the structure before adding data to it */
-	bzero(&sockaddr, sizeof(sockaddr));
+	memset(&sockaddr, '\0', sizeof(sockaddr));
 
 	/* Next, we read the socket address structure from the tracee's memory */
 	status = read_data(tracee, &sockaddr, *sock_addr, size);
@@ -363,7 +363,7 @@ int add_changed_port_as_entry(Tracee *tracee, Config *config, word_t sockfd, wor
 		return -result;
 
 	/* Essential step, we clean the structure before adding data to it */
-	bzero(&sockaddr, sizeof(sockaddr));
+	memset(&sockaddr, '\0', sizeof(sockaddr));
 
 	/* Next, we read the socket address structure from the tracee's memory */
 	status = read_data(tracee, &sockaddr, sock_addr, sizeof(sockaddr));

--- a/src/ptrace/ptrace.c
+++ b/src/ptrace/ptrace.c
@@ -58,7 +58,7 @@
 #define user_fpregs_struct user_fpsimd_struct
 #endif
 
-static const char *stringify_ptrace(enum __ptrace_request request)
+static const char *stringify_ptrace(PTRACE_REQUEST_TYPE request)
 {
 #define CASE_STR(a) case a: return #a; break;
 	switch ((int) request) {

--- a/src/syscall/enter.c
+++ b/src/syscall/enter.c
@@ -26,7 +26,7 @@
 #include <linux/net.h>   /* SYS_*, */
 #include <fcntl.h>       /* AT_FDCWD, */
 #include <limits.h>      /* PATH_MAX, */
-
+#include <string.h>	 /* strcpy */
 #include "syscall/syscall.h"
 #include "syscall/sysnum.h"
 #include "syscall/socket.h"

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -45,6 +45,10 @@
 
 #include "compat.h"
 
+#ifndef __W_STOPCODE
+#define __W_STOPCODE(sig)	((sig) <<8 | 0x7f)
+#endif
+
 typedef LIST_HEAD(tracees, tracee) Tracees;
 static Tracees tracees;
 

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -34,6 +34,12 @@
 #include "arch.h" /* word_t, user_regs_struct, */
 #include "compat.h"
 
+#if defined(__GLIBC__)
+#define PRACE_REQUEST_TYPE	enum __ptrace_request
+#else
+#define PTRACE_REQUEST_TYPE	int
+#endif
+
 typedef enum {
 	CURRENT  = 0,
 	ORIGINAL = 1,
@@ -147,7 +153,7 @@ typedef struct tracee {
 				     && get_sysnum((tracee), ORIGINAL) == sysnum)
 
 	/* How this tracee is restarted.  */
-	enum __ptrace_request restart_how;
+	PTRACE_REQUEST_TYPE restart_how;
 
 	/* Value of the tracee's general purpose registers.  */
 	struct user_regs_struct _regs[NB_REG_VERSION];

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -30,7 +30,7 @@
 #include <sys/ptrace.h>/* enum __ptrace_request */
 #include <talloc.h>    /* talloc_*, */
 #include <stdint.h>    /* *int*_t, */
-
+#include <sys/wait.h>  /* __WAIT_* */
 #include "arch.h" /* word_t, user_regs_struct, */
 #include "compat.h"
 


### PR DESCRIPTION
Allow compiling against musl libc.  Hides glibc-specific behaviour behind #ifdefs and makes sure macros are defined.  Also moves from nonstandard bzero to using memset.
