### PR TITLE
Support for bootstrapping Alpine Linux rootfs

### DIFF
--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -664,6 +664,7 @@ static int handle_sysexit_end(Tracee *tracee, Config *config)
 
 	case PR_chroot: {
 		char path[PATH_MAX];
+		char abspath[PATH_MAX];
 		word_t input;
 		int status;
 
@@ -681,8 +682,12 @@ static int handle_sysexit_end(Tracee *tracee, Config *config)
 		if (status < 0)
 			return status;
 
+		/* Resolve relative path segments. */
+		if (!realpath(path, abspath))
+			return 0;
+
 		/* Only "new rootfs == current rootfs" is supported yet.  */
-		status = compare_paths(get_root(tracee), path);
+		status = compare_paths(get_root(tracee), abspath);
 		if (status != PATHS_ARE_EQUAL)
 			return 0;
 

--- a/tests/GNUmakefile
+++ b/tests/GNUmakefile
@@ -111,7 +111,8 @@ ROOTFS_BIN = $(ROOTFS)/bin/true $(ROOTFS)/bin/false    				 \
        $(ROOTFS)/bin/fork-wait $(ROOTFS)/bin/ptrace $(ROOTFS)/bin/ptrace-2	 \
        $(ROOTFS)/bin/puts_proc_self_exe $(ROOTFS)/bin/exec $(ROOTFS)/bin/exec-m32 \
        $(ROOTFS)/bin/exec-suid $(ROOTFS)/bin/exec-sgid $(ROOTFS)/bin/exec-m32-suid \
-       $(ROOTFS)/bin/exec-m32-sgid $(ROOTFS)/bin/getresuid $(ROOTFS)/bin/getresgid
+       $(ROOTFS)/bin/exec-m32-sgid $(ROOTFS)/bin/getresuid $(ROOTFS)/bin/getresgid \
+       $(ROOTFS)/bin/chroot
 
 ROOTFS_DIR = $(ROOTFS)/bin $(ROOTFS)/tmp
 

--- a/tests/chroot.c
+++ b/tests/chroot.c
@@ -1,0 +1,19 @@
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+	if (argc < 2)
+		exit(1);
+
+	if (chroot(argv[1]))
+		exit(1);
+
+	if (argc >= 3)
+		execvp(argv[2], &argv[2]);
+	else
+		execlp("sh", "sh", NULL);
+
+	/* unreachable */
+	return 1;
+}

--- a/tests/test-chroot01.sh
+++ b/tests/test-chroot01.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ ! -x ${ROOTFS}/bin/true -o ! -x ${ROOTFS}/bin/chroot ]; then
+    exit 125;
+fi
+
+${PROOT} -0 -r ${ROOTFS} -w / /bin/chroot . /bin/true


### PR DESCRIPTION
Previous fix (1fc2739) does not work for me.

From what I understand it tries to translate the path to the host's realm, even though this has already been taken care of by `translate_syscall_enter`.

It seems to me like all we need to do is to resolve any relative path segments in `path` and then compare that to the tracee's root.