### PR TITLE
Added Void Linux to Ecosystem

### DIFF
--- a/doc/proot/manual.txt
+++ b/doc/proot/manual.txt
@@ -603,6 +603,8 @@ Binaries from the Downloads_ section are likely more up-to-date.
 
 * `Arch Linux <https://aur.archlinux.org/packages/proot>`_
 
+* `Void Linux <https://github.com/void-linux/void-packages/tree/master/srcpkgs/proot>`_
+
 * `Gentoo <http://packages.gentoo.org/package/sys-apps/proot>`_
 
 * `Debian <https://packages.debian.org/sid/proot>`_


### PR DESCRIPTION
Adds Void Linux to the ecosystem. Should close issue #175 