### PR TITLE
docs: fix simple typo, othrwise -> otherwise

### DIFF
--- a/src/path/path.c
+++ b/src/path/path.c
@@ -282,7 +282,7 @@ void chop_finality(char *path)
 
 /**
  * Put in @path the result of readlink(/proc/@pid/fd/@fd).  This
- * function returns -errno if an error occured, othrwise 0.
+ * function returns -errno if an error occured, otherwise 0.
  */
 int readlink_proc_pid_fd(pid_t pid, int fd, char path[PATH_MAX])
 {


### PR DESCRIPTION
There is a small typo in src/path/path.c.

Should read `otherwise` rather than `othrwise`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md