### PR TITLE
Fixes to seccomp event handling logic

### DIFF
--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -379,11 +379,11 @@ int event_loop()
 				continue;
 		}
 
-                if (kernel_4_8) {
-		     signal = handle_tracee_event_kernel_4_8(tracee, tracee_status);
+		if (kernel_4_8) {
+			signal = handle_tracee_event_kernel_4_8(tracee, tracee_status);
 		}
 		else {
-		     signal = handle_tracee_event(tracee, tracee_status);
+			signal = handle_tracee_event(tracee, tracee_status);
 		}
 		(void) restart_tracee(tracee, signal);
 	}
@@ -491,37 +491,37 @@ int handle_tracee_event_kernel_4_8(Tracee *tracee, int tracee_status)
 		case SIGTRAP | PTRACE_EVENT_SECCOMP2 << 8:
 		case SIGTRAP | PTRACE_EVENT_SECCOMP << 8:
 
-                	if (!seccomp_detected && seccomp_enabled) {
+			if (!seccomp_detected && seccomp_enabled) {
 				VERBOSE(tracee, 1, "ptrace acceleration (seccomp mode 2) enabled");
 				tracee->seccomp = ENABLED;
 				seccomp_detected = true;
 			}
 
 			if (signal == (SIGTRAP | PTRACE_EVENT_SECCOMP2 << 8) ||
-                            signal == (SIGTRAP | PTRACE_EVENT_SECCOMP << 8)) {
+			    signal == (SIGTRAP | PTRACE_EVENT_SECCOMP << 8)) {
 
 				unsigned long flags = 0;
 				signal = 0;
-	
+
 				/* SECCOMP TRAP can only be received for
- 				 * sysenter events, ignore otherwise */
+				 * sysenter events, ignore otherwise */
 				if (!IS_IN_SYSENTER(tracee)) {
 					tracee->restart_how = PTRACE_CONT;
 					return 0;
-                               	}
-                                status = ptrace(PTRACE_GETEVENTMSG, tracee->pid, NULL, &flags);
-                                if (status < 0)
-                                        break;
+				}
+				status = ptrace(PTRACE_GETEVENTMSG, tracee->pid, NULL, &flags);
+				if (status < 0)
+					break;
 
-                                    if (tracee->seccomp == ENABLED && (flags & FILTER_SYSEXIT) == 0) {
-                        		tracee->restart_how = PTRACE_CONT;
-                        		translate_syscall(tracee);
+				if (tracee->seccomp == ENABLED && (flags & FILTER_SYSEXIT) == 0) {
+					tracee->restart_how = PTRACE_CONT;
+					translate_syscall(tracee);
 
-                        		if (tracee->seccomp == DISABLING)
-                                		tracee->restart_how = PTRACE_SYSCALL;
-                        		break;
-                                    }
-                	}
+					if (tracee->seccomp == DISABLING)
+						tracee->restart_how = PTRACE_SYSCALL;
+					break;
+				}
+			}
 
 			/* Fall through. */
 		case SIGTRAP | 0x80:
@@ -531,7 +531,7 @@ int handle_tracee_event_kernel_4_8(Tracee *tracee, int tracee_status)
 			/* This tracee got signaled then freed during the
 			   sysenter stage but the kernel reports the sysexit
 			   stage; just discard this spurious tracee/event.  */
-                        
+
 			if (tracee->exe == NULL) {
 				tracee->restart_how = PTRACE_CONT; /* SYSCALL OR CONT */
 				return 0;

--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -212,14 +212,14 @@ static int last_exit_status = -1;
  */
 bool is_kernel_4_8(void)
 {
-    static int version_48 = -1;
-    static int major = 0;
-    static int minor = 0;
+	static int version_48 = -1;
+	int major = 0;
+	int minor = 0;
 
 	if (version_48 != -1)
 		return version_48;
 
-    version_48 = false;
+	version_48 = false;
 
 	struct utsname utsname;
 
@@ -228,8 +228,8 @@ bool is_kernel_4_8(void)
 
 	sscanf(utsname.release, "%d.%d", &major, &minor);
 
-	if (major >= 4 && minor >= 8)
-			version_48 = true;
+	if ((major == 4 && minor >= 8) || major > 4)
+		version_48 = true;
 
 	return version_48;
 }

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -29,6 +29,9 @@ check-%.c: $(ROOTFS)/bin/% setup
 	$(call check_c,$*,$(PROOT) -b /proc -r $(ROOTFS) /bin/$*)
 
 # Special cases.
+check-test-sysexit.c: test-sysexit
+	$(call check_c,$<,env PROOT_FORCE_KOMPAT=1 $(PROOT) -k 3.4242XX ./$<)
+
 check-test-bdc90417.c: test-bdc90417
 	$(call check_c,$<,$(PROOT) -w . ./$<)
 

--- a/test/test-sysexit.c
+++ b/test/test-sysexit.c
@@ -1,0 +1,35 @@
+/* -*- c-set-style: "K&R"; c-basic-offset: 8 -*- */
+#include <stdlib.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>  /* wait(2), */
+#include <unistd.h>
+#include <string.h>
+
+/* Related to github issue #106.
+ * Test if sysexit handlers execute, using uname handling
+ * in the kompat extension. The test case is meant to be
+ * run with "-k 3.4242XX" cmdline argument.
+ * The bug could occur during the first traced syscall,
+ * before seccomp got enabled.
+ * However there was some kind of a random factor there,
+ * so we fork out many processes to make it likely that at least
+ * some would hit this problem. */
+
+int main()
+{
+	int status;
+	struct utsname s;
+	for (int i = 0; i < 5; i++) {
+		fork();
+	}
+	uname(&s);
+	int child_status;
+	while ((status = wait(&child_status)) >= 0) {
+		if (!WIFEXITED(child_status) || (WEXITSTATUS(child_status) == EXIT_FAILURE))
+			exit(EXIT_FAILURE);
+	}
+	if (strcmp("3.4242XX", s.release) == 0) {
+		exit(EXIT_SUCCESS);
+	}
+	exit(EXIT_FAILURE);
+}


### PR DESCRIPTION
- Fix a bug in seccomp event handling logic, that could cause sysexit events handler to be missed if sysenter is handled during a syscall-enter-stop event instead of the seccomp ptrace event. A test case for this behavior is also added.
- make kernel version detection work for major versions > 4.
- indentation fixes
- Remove some preprocessor directives and code that tie runtime behavior to compilation environment, which is the wrong thing to do.

This may be a (at least partial) fix for issue #106.