### PR TITLE
fake_id0: Fix POKE_MEM_ID to call poke_uint32 instead of poke_uint16

### DIFF
--- a/src/extension/fake_id0/fake_id0.c
+++ b/src/extension/fake_id0/fake_id0.c
@@ -313,7 +313,7 @@ static int handle_sysenter_end(Tracee *tracee, const Config *config)
  * Copy config->@field to the tracee's memory location pointed to by @sysarg.
  */
 #define POKE_MEM_ID(sysarg, field) do {					\
-	poke_uint16(tracee, peek_reg(tracee, ORIGINAL, sysarg), config->field);	\
+	poke_uint32(tracee, peek_reg(tracee, ORIGINAL, sysarg), config->field);	\
 	if (errno != 0)							\
 		return -errno;						\
 } while (0)


### PR DESCRIPTION
Fix getresuid() and getresgid() uses the POKE_MEM_ID macro when using
fake_id0, this was the only macro that was using 16bits return value
for IDs.

This behavior causes some applications, such as apt-get, to not get
proper results when the host user has an UID greater than 16bits.