### PR TITLE
Make sure `/bin` is in PATH during test

### DIFF
--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -23,7 +23,7 @@ check_failure: $(CHECK_TESTS)
 	@bash -c '! test -e failure'
 
 check-%.sh: %.sh setup
-	$(Q)env CARE="$(CARE)" PROOT_RAW="$(PROOT_RAW)" PROOT="$(PROOT)" ROOTFS=$(ROOTFS) sh -ex $< $(silently); $(call check,$*)
+	$(Q)env CARE="$(CARE)" PROOT_RAW="$(PROOT_RAW)" PROOT="$(PROOT)" ROOTFS=$(ROOTFS) PATH="$${PATH}:/bin" sh -ex $< $(silently); $(call check,$*)
 
 check-%.c: $(ROOTFS)/bin/% setup
 	$(call check_c,$*,$(PROOT) -b /proc -r $(ROOTFS) /bin/$*)


### PR DESCRIPTION
On ArchLinux, where `/bin` is no longer in `PATH` by default
this fixes about 10 test failures.

Not sure if this is the cleanest way but this is the test so ....
