### PR TITLE
Enable github action for testing

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: "Test ${{ matrix.SECCOMP == '1' && 'With seccomp' || 'No seccomp' }}"
+    name: "Test ${{ matrix.SECCOMP == '1' && 'with seccomp' || 'no seccomp' }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -36,6 +36,6 @@ jobs:
         run: |
           env ${{ matrix.SECCOMP == '0' && 'PROOT_NO_SECCOMP=1' || '' }} PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PWD/src make -C test -j $(nproc) QUIET_LOG=$PWD/test.log
 
-      - name: Test log
+      - name: Log
         if: always()
         run: ([ -f test.log ] && cat test.log) || true

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,0 +1,41 @@
+name: Ubuntu
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: "Test ${{ matrix.SECCOMP == '1' && 'With seccomp' || 'No seccomp' }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        SECCOMP: [ 0, 1 ]
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq clang-tools-6.0 curl gdb lcov libarchive-dev libtalloc-dev sloccount strace swig uthash-dev python3-dev
+
+      - name: Info
+        run: sloccount --details .
+
+      - name: Build
+        run: |
+          make -C src loader.elf loader-m32.elf build.h
+          env CFLAGS=--coverage LDFLAGS=--coverage make -C src proot care V=1
+
+      - name: Test
+        run: |
+          env ${{ matrix.SECCOMP == '0' && 'PROOT_NO_SECCOMP=1' || '' }} PATH=/bin:/usr/bin:/sbin:/usr/sbin:$PWD/src make -C test -j $(nproc) QUIET_LOG=$PWD/test.log
+
+      - name: Test log
+        if: always()
+        run: ([ -f test.log ] && cat test.log) || true

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -208,10 +208,11 @@ test-c47aeb7d: test-c47aeb7d.c
 # Beautified output
 
 V = 0
+QUIET_LOG = /dev/null
 ifeq ($(V), 0)
     quiet = quiet_
     Q     = @
-    silently = >/dev/null 2>&1
+    silently = >> $(QUIET_LOG) 2>&1
 else
     quiet = 
     Q     = 


### PR DESCRIPTION
Add a `QUIET_LOG` option for the test makefile to allow printing the full log
while still having a nice summary of the test results.

I see that there's already a gitlab-ci but this might be easier to integrate with github (e.g. pull requests).
The apparently newer python dependency is also how I noticed https://github.com/proot-me/proot/pull/285 (I didn't have swig installed locally).

Even if a new CI setup isn't desired, I think the QUIET_LOG option is still useful for CI. I can split that out if needed....