### PR TITLE
Fix event handling on newer kernels

### DIFF
--- a/src/tracee/event.h
+++ b/src/tracee/event.h
@@ -30,7 +30,6 @@
 extern int launch_process(Tracee *tracee, char *const argv[]);
 extern int event_loop();
 extern int handle_tracee_event(Tracee *tracee, int tracee_status);
-extern int handle_tracee_event_kernel_4_8(Tracee *tracee, int tracee_status);
 extern bool restart_tracee(Tracee *tracee, int signal);
 
 #endif /* TRACEE_EVENT_H */

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -108,6 +108,7 @@ ROOTFS_BIN = $(ROOTFS)/bin/true $(ROOTFS)/bin/false    				 \
        $(ROOTFS)/bin/argv0 $(ROOTFS)/bin/readdir $(ROOTFS)/bin/cat		 \
        $(ROOTFS)/bin/chdir_getcwd $(ROOTFS)/bin/fchdir_getcwd $(ROOTFS)/bin/argv \
        $(ROOTFS)/bin/fork-wait $(ROOTFS)/bin/ptrace $(ROOTFS)/bin/ptrace-2	 \
+       $(ROOTFS)/bin/ptrace-3	\
        $(ROOTFS)/bin/puts_proc_self_exe $(ROOTFS)/bin/exec $(ROOTFS)/bin/exec-m32 \
        $(ROOTFS)/bin/exec-suid $(ROOTFS)/bin/exec-sgid $(ROOTFS)/bin/exec-m32-suid \
        $(ROOTFS)/bin/exec-m32-sgid $(ROOTFS)/bin/getresuid $(ROOTFS)/bin/getresgid \

--- a/test/ptrace-3.c
+++ b/test/ptrace-3.c
@@ -1,0 +1,80 @@
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ptrace.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <errno.h>      /* errno(3), */
+#include <sys/user.h>   /* struct user*, */
+
+int main(int argc, char **argv)
+{
+	enum __ptrace_request restart_how;
+	int last_exit_status = -1;
+	int child_status;
+	pid_t *pids = NULL;
+	long status;
+	int signal;
+	pid_t pid;
+
+	if (argc <= 1) {
+		fprintf(stderr, "Usage: %s /path/to/exe [args]\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	pid = fork();
+	switch(pid) {
+	case -1:
+		perror("fork()");
+		exit(EXIT_FAILURE);
+
+	case 0: /* child */
+		status = ptrace(PTRACE_TRACEME, 0, NULL, NULL);
+		if (status < 0) {
+			perror("ptrace(TRACEME)");
+			exit(EXIT_FAILURE);
+		}
+
+		/* Synchronize with the tracer's event loop.  */
+		kill(getpid(), SIGSTOP);
+
+		execvp(argv[1], &argv[1]);
+		exit(EXIT_FAILURE);
+
+	default: /* parent */
+		break;
+	}
+
+	while (1) {
+		int tracee_status;
+		pid = waitpid(-1, &tracee_status, __WALL);
+		if (pid < 0) {
+			perror("waitpid()");
+			if (errno != ECHILD)
+				exit(EXIT_FAILURE);
+			break;
+		}
+
+		if (WIFEXITED(tracee_status)) {
+			fprintf(stderr, "pid %d: exited with status %d\n",
+				pid, WEXITSTATUS(tracee_status));
+			last_exit_status = WEXITSTATUS(tracee_status);
+			continue; /* Skip the call to ptrace(SYSCALL). */
+		}
+		else if (WIFSTOPPED(tracee_status)) {
+			int signal = tracee_status >> 8;
+			if (signal != SIGTRAP && signal != SIGSTOP) {
+				// We expect a SIGSTOP since the child sends it to itself
+				// and a SIGTRAP from the exec + ptrace.
+				// Anything else is an error.
+				fprintf(stderr, "Unexpected signal recieved from pid: %d.\n",
+					pid);
+				exit(EXIT_FAILURE);
+			}
+			status = ptrace(PTRACE_CONT, pid, NULL, 0);
+		}
+	}
+
+	return last_exit_status;
+}

--- a/test/test-ptrace-exec-trap.sh
+++ b/test/test-ptrace-exec-trap.sh
@@ -1,0 +1,26 @@
+if [ -z `which mcookie` ] || [ -z `which cmp` ] || [ -z `which rm` ] || [ ! -x  ${ROOTFS}/bin/ptrace-3 ] || [ ! -x  ${ROOTFS}/bin/true ]; then
+    exit 125;
+fi
+
+TMP1=/tmp/$(mcookie)
+TMP2=/tmp/$(mcookie)
+
+${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP1}
+
+${PROOT} ${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP2}
+
+cmp ${TMP1} ${TMP2}
+
+PTRACER_BEHAVIOR_1=1 ${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP1}
+
+PTRACER_BEHAVIOR_1=1 ${PROOT} ${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP2}
+
+cmp ${TMP1} ${TMP2}
+
+PTRACER_BEHAVIOR_2=1 ${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP1}
+
+PTRACER_BEHAVIOR_2=1 ${PROOT} ${ROOTFS}/bin/ptrace-3 ${ROOTFS}/bin/true 2>&1 >${TMP2}
+
+cmp ${TMP1} ${TMP2}
+
+rm -f ${TMP1} ${TMP2}


### PR DESCRIPTION
The event handler for the old kernel may still be called on new kernels.
This causes issues since the two event handlers maintains their own global states
unaware of each other.

In particular, execve+ptrace handling from the loader of the tracee
will issue an `execve(0x1, ...)` to signal proot of the start addresses.
This triggers a `SIGTRAP` to the tracee for the tracer to handle.
However, the event handler expect one initial `SIGTRAP` to have special meaning
and if the wrong event handler is called, it will incorrectly assume this `SIGTRAP`
is the special one and acts incorrectly. (In this case, causing the signaling `execve`
to run again and set the addresses incorrectly.)

Noticed this as a new error when debugging `test-0228fbe7` with `seccomp` disabled and it turns out that this fixes `test-0228fbe7` with `seccomp` disabled as well. When testing locally, this doesn't introduce any test regressions with or without `seccomp` enabled....