### PR TITLE
Fix and improve docker test skip detection

### DIFF
--- a/test/test-docker.sh
+++ b/test/test-docker.sh
@@ -3,12 +3,11 @@ set -eu
 
 # Test can run using either builder
 BUILDER="docker"
-if [ -z "$(command -v ${BUILDER})" ]; then
-BUILDER="img"
-else
-  if [ -z "$(command -v ${BUILDER})" ]; then
-    exit 125
-  fi
+if [ -z "$(command -v ${BUILDER})" ] || ! docker run hello-world > /dev/null 2>&1; then
+    BUILDER="img"
+    if [ -z "$(command -v ${BUILDER})" ]; then
+        exit 125
+    fi
 fi
 
 # Export for use in subshell


### PR DESCRIPTION
* Make sure we actually check if `img` is available
  The current logic checks if docker is available a second time if it is available
  and set the builder to img without checking if docker isn't available.
* Check if docker can run hello-world to catch permission error for the running user.