### PR TITLE
Install LZOP on CI for CARE archive extraction

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq clang-tools-6.0 curl gdb lcov libarchive-dev libtalloc-dev sloccount strace swig uthash-dev python3-dev
+          sudo apt-get install -qq clang-tools-6.0 curl gdb lcov libarchive-dev libtalloc-dev sloccount strace swig uthash-dev python3-dev lzop
 
       - name: Info
         run: sloccount --details .


### PR DESCRIPTION
With these plus a WIP change (https://github.com/yuyichao/proot/commit/6bf72a7bff316514e89ed982bb253c091b534d4d) the test finally [passes on the CI](https://github.com/yuyichao/proot/runs/3791513021?check_suite_focus=true) with seccomp disabled....
