### PR TITLE
Change restart_original_syscall to not use chained syscall

### DIFF
--- a/src/ptrace/wait.h
+++ b/src/ptrace/wait.h
@@ -26,7 +26,7 @@
 #include "tracee/tracee.h"
 
 extern int translate_wait_enter(Tracee *ptracer);
-extern int translate_wait_exit(Tracee *ptracer);
+extern int translate_wait_exit(Tracee *ptracer, bool *set_result);
 extern bool handle_ptracee_event(Tracee *ptracee, int wait_status);
 
 /* __WCLONE: Wait for "clone" children only.  If omitted then wait for

--- a/src/syscall/chain.c
+++ b/src/syscall/chain.c
@@ -145,12 +145,17 @@ void force_chain_final_result(Tracee *tracee, word_t forced_result)
  */
 int restart_original_syscall(Tracee *tracee)
 {
-	return register_chained_syscall(tracee,
-					get_sysnum(tracee, ORIGINAL),
-					peek_reg(tracee, ORIGINAL, SYSARG_1),
-					peek_reg(tracee, ORIGINAL, SYSARG_2),
-					peek_reg(tracee, ORIGINAL, SYSARG_3),
-					peek_reg(tracee, ORIGINAL, SYSARG_4),
-					peek_reg(tracee, ORIGINAL, SYSARG_5),
-					peek_reg(tracee, ORIGINAL, SYSARG_6));
+	poke_reg(tracee, SYSARG_1, peek_reg(tracee, ORIGINAL, SYSARG_1));
+	poke_reg(tracee, SYSARG_2, peek_reg(tracee, ORIGINAL, SYSARG_2));
+	poke_reg(tracee, SYSARG_3, peek_reg(tracee, ORIGINAL, SYSARG_3));
+	poke_reg(tracee, SYSARG_4, peek_reg(tracee, ORIGINAL, SYSARG_4));
+	poke_reg(tracee, SYSARG_5, peek_reg(tracee, ORIGINAL, SYSARG_5));
+	poke_reg(tracee, SYSARG_6, peek_reg(tracee, ORIGINAL, SYSARG_6));
+	poke_reg(tracee, SYSTRAP_NUM, peek_reg(tracee, ORIGINAL, SYSARG_NUM));
+
+	/* Move the instruction pointer back to the original trap.  */
+	poke_reg(tracee, INSTR_POINTER,
+		peek_reg(tracee, CURRENT, INSTR_POINTER) - SYSTRAP_SIZE);
+
+	return 0;
 }

--- a/src/syscall/exit.c
+++ b/src/syscall/exit.c
@@ -436,12 +436,16 @@ void translate_syscall_exit(Tracee *tracee)
 		break;
 
 	case PR_wait4:
-	case PR_waitpid:
+	case PR_waitpid: {
+		bool set_result = true;
 		if (tracee->as_ptracer.waits_in != WAITS_IN_PROOT)
 			goto end;
 
-		status = translate_wait_exit(tracee);
+		status = translate_wait_exit(tracee, &set_result);
+		if (!set_result)
+			goto end;
 		break;
+	}
 
 	case PR_setrlimit:
 	case PR_prlimit64:

--- a/test/GNUmakefile
+++ b/test/GNUmakefile
@@ -108,7 +108,7 @@ ROOTFS_BIN = $(ROOTFS)/bin/true $(ROOTFS)/bin/false    				 \
        $(ROOTFS)/bin/argv0 $(ROOTFS)/bin/readdir $(ROOTFS)/bin/cat		 \
        $(ROOTFS)/bin/chdir_getcwd $(ROOTFS)/bin/fchdir_getcwd $(ROOTFS)/bin/argv \
        $(ROOTFS)/bin/fork-wait $(ROOTFS)/bin/ptrace $(ROOTFS)/bin/ptrace-2	 \
-       $(ROOTFS)/bin/ptrace-3 $(ROOTFS)/bin/gdb-ptrace-test	\
+       $(ROOTFS)/bin/ptrace-3 $(ROOTFS)/bin/gdb-ptrace-test $(ROOTFS)/bin/gdb-ptrace-test-signal	\
        $(ROOTFS)/bin/puts_proc_self_exe $(ROOTFS)/bin/exec $(ROOTFS)/bin/exec-m32 \
        $(ROOTFS)/bin/exec-suid $(ROOTFS)/bin/exec-sgid $(ROOTFS)/bin/exec-m32-suid \
        $(ROOTFS)/bin/exec-m32-sgid $(ROOTFS)/bin/getresuid $(ROOTFS)/bin/getresgid \

--- a/test/gdb-ptrace-test-signal.c
+++ b/test/gdb-ptrace-test-signal.c
@@ -1,0 +1,169 @@
+//
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ptrace.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../src/compat.h"
+
+static int fork_to_function(int (*function)(void))
+{
+	int child_pid = fork();
+
+	if (child_pid == -1) {
+		perror("fork()");
+		exit(EXIT_FAILURE);
+	}
+
+	if (child_pid == 0)
+		return function();
+
+	return child_pid;
+}
+
+static int grandchild_function(void)
+{
+	exit(0);
+}
+
+static int child_function(void)
+{
+	ptrace(PTRACE_TRACEME, 0, 0, 0);
+	kill(getpid(), SIGSTOP);
+
+	fork_to_function(grandchild_function);
+
+	exit(0);
+}
+
+static void kill_child(int child_pid)
+{
+	pid_t got_pid;
+	int kill_status;
+
+	if (kill(child_pid, SIGKILL) != 0) {
+		perror("kill()");
+		exit(EXIT_FAILURE);
+	}
+
+	got_pid = waitpid (child_pid, &kill_status, 0);
+	if (got_pid != child_pid) {
+		fprintf(stderr, "waitpid: unexpected result %d.", (int)got_pid);
+		exit(EXIT_FAILURE);
+	}
+
+	if (!WIFSIGNALED(kill_status)) {
+		fprintf(stderr, "waitpid: unexpected status %d.", kill_status);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void test_tracefork(int child_pid)
+{
+	int ret, status;
+	long second_pid;
+
+	ret = ptrace(PTRACE_SETOPTIONS, child_pid, 0, PTRACE_O_TRACEFORK);
+	if (ret != 0) {
+		// Skipped
+		perror("ptrace(PTRACE_SETOPTIONS, PTRACE_O_TRACEFORK)");
+		kill_child(child_pid);
+		exit(125);
+	}
+
+	ret = ptrace (PTRACE_CONT, child_pid, 0, 0);
+	if (ret != 0) {
+		perror("ptrace(PTRACE_CONT)");
+		kill_child(child_pid);
+		exit(EXIT_FAILURE);
+	}
+
+	ret = waitpid(child_pid, &status, 0);
+	/* Check if we received a fork event notification.  */
+	if (ret == child_pid && WIFSTOPPED(status) && (status >> 16) == PTRACE_EVENT_FORK) {
+		/* We did receive a fork event notification.  Make sure its PID
+		   is reported.  */
+		second_pid = 0;
+		ret = ptrace(PTRACE_GETEVENTMSG, child_pid, 0, &second_pid);
+		if (ret == 0 && second_pid != 0) {
+			int second_status;
+
+			/* Do some cleanup and kill the grandchild.  */
+			waitpid(second_pid, &second_status, 0);
+			kill_child(second_pid);
+		}
+		else {
+			perror("ptrace(PTRACE_GETEVENTMSG)");
+			exit(EXIT_FAILURE);
+		}
+	}
+	else {
+		fprintf(stderr, "Unexpected result from waitpid: pid=%d, status=%d\n", ret, status);
+		exit(EXIT_FAILURE);
+	}
+}
+
+static void check_ptrace_features(int do_fork)
+{
+	int child_pid, ret, status;
+
+	child_pid = fork_to_function(child_function);
+
+	ret = waitpid(child_pid, &status, 0);
+	if (ret == -1) {
+		perror("waitpid()");
+		exit(EXIT_FAILURE);
+	}
+	else if (ret != child_pid) {
+		fprintf(stderr, "waitpid: unexpected result %d.", ret);
+		exit(EXIT_FAILURE);
+	}
+	else if (!WIFSTOPPED(status)) {
+		fprintf(stderr, "waitpid: unexpected status %d.", status);
+		exit(EXIT_FAILURE);
+	}
+
+	if (do_fork)
+		test_tracefork(child_pid);
+
+	kill_child(child_pid);
+}
+
+static int devnull = -1;
+
+// SIGCHLD handler which has a high chance of triggering
+// right before the chained wait4 call.
+// We need to make sure things are handled correctly even if we
+static void sigchld_handler(int signo)
+{
+	if (devnull != -1)
+		close(devnull);
+	devnull = open("/dev/null", O_RDONLY);
+	if (devnull == -1) {
+		perror("open(/dev/null)");
+		exit(EXIT_FAILURE);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	struct sigaction sigchld_action = {};
+	sigchld_action.sa_handler = sigchld_handler;
+	sigemptyset (&sigchld_action.sa_mask);
+	sigchld_action.sa_flags = SA_RESTART;
+
+	/* Make it the default.  */
+	sigaction(SIGCHLD, &sigchld_action, NULL);
+	(void)argv;
+	check_ptrace_features(argc > 1);
+	if (devnull == -1) {
+		fprintf(stderr, "SIGCHLD handler not called.\n");
+		exit(EXIT_FAILURE);
+	}
+	close(devnull);
+	return 0;
+}

--- a/test/test-gdb-ptrace.sh
+++ b/test/test-gdb-ptrace.sh
@@ -1,4 +1,4 @@
-if [ ! -x  ${ROOTFS}/bin/gdb-ptrace-test ]; then
+if [ ! -x  ${ROOTFS}/bin/gdb-ptrace-test ] || [ ! -x  ${ROOTFS}/bin/gdb-ptrace-test-signal ]; then
     exit 125;
 fi
 
@@ -6,3 +6,8 @@ ${ROOTFS}/bin/gdb-ptrace-test
 ${ROOTFS}/bin/gdb-ptrace-test 1
 ${PROOT} ${ROOTFS}/bin/gdb-ptrace-test
 ${PROOT} ${ROOTFS}/bin/gdb-ptrace-test 1
+
+${ROOTFS}/bin/gdb-ptrace-test-signal
+${ROOTFS}/bin/gdb-ptrace-test-signal 1
+${PROOT} ${ROOTFS}/bin/gdb-ptrace-test-signal
+${PROOT} ${ROOTFS}/bin/gdb-ptrace-test-signal 1


### PR DESCRIPTION
If we are simply restarting a syscall, there's no need to do anything afterwards
to restore any register values so we don't really need to keep a record of it ourselves
in the chain syscall list.

By simply resetting the PC and the arguments, we avoid issue #292 for this function
when we get a signal before we run the restarted syscall and confused syscall
from the signal handler as the one we restarted (chained).