### PR TITLE
Some printing tweaks

### DIFF
--- a/src/tracee/event.c
+++ b/src/tracee/event.c
@@ -366,6 +366,9 @@ int event_loop()
 
 		tracee->running = false;
 
+		VERBOSE(tracee, 6, "vpid %" PRIu64 ": got event %x",
+			tracee->vpid, tracee_status);
+
 		status = notify_extensions(tracee, NEW_STATUS, tracee_status, 0);
 		if (status != 0)
 			continue;
@@ -425,7 +428,7 @@ static int handle_tracee_event_kernel_4_8(Tracee *tracee, int tracee_status)
 	}
 	else if (WIFSIGNALED(tracee_status)) {
 		check_architecture(tracee);
-		VERBOSE(tracee, (int) (last_exit_status != -1),
+		VERBOSE(tracee, 1,
 			"vpid %" PRIu64 ": terminated with signal %d",
 			tracee->vpid, WTERMSIG(tracee_status));
 		terminate_tracee(tracee);
@@ -672,7 +675,7 @@ int handle_tracee_event(Tracee *tracee, int tracee_status)
 	}
 	else if (WIFSIGNALED(tracee_status)) {
 		check_architecture(tracee);
-		VERBOSE(tracee, (int) (last_exit_status != -1),
+		VERBOSE(tracee, 1,
 			"vpid %" PRIu64 ": terminated with signal %d",
 			tracee->vpid, WTERMSIG(tracee_status));
 		terminate_tracee(tracee);
@@ -876,6 +879,9 @@ bool restart_tracee(Tracee *tracee, int signal)
 	status = ptrace(tracee->restart_how, tracee->pid, NULL, signal);
 	if (status < 0)
 		return false; /* The process likely died in a syscall.  */
+
+	VERBOSE(tracee, 6, "vpid %" PRIu64 ": restarted using %d, signal %d",
+		tracee->vpid, tracee->restart_how, signal);
 
 	tracee->restart_how = 0;
 	tracee->running = true;


### PR DESCRIPTION
* Add a message for stopping and starting of tracees
* Try not to print anything by default

The additional message was what I found useful for most of the debugging, since it gives the most complete picture about the starting and stopping about tracees. And I found myself adding and removing these printings way too many times....

The other change makes it annoy to run programs that are meant/known to error under proot. Unless there's some internal fatal error, I don't think we need to print any output by default...
