### PR TITLE
Remove special handling of syscall avoider number on ARM

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -31,7 +31,7 @@
 typedef unsigned long word_t;
 typedef unsigned char byte_t;
 
-#define SYSCALL_AVOIDER ((word_t) -2)
+#define SYSCALL_AVOIDER ((word_t) -1)
 #define SYSTRAP_NUM SYSARG_NUM
 #define STACK_ALIGNMENT 16
 
@@ -109,11 +109,6 @@ typedef unsigned char byte_t;
 
     #define EXEC_PIC_ADDRESS   0x0f000000
     #define INTERP_PIC_ADDRESS 0x1f000000
-
-    /* The syscall number has to be valid on ARM, so use tuxcall(2) as
-     * the "void" syscall since it has no side effects.  */
-    #undef SYSCALL_AVOIDER
-    #define SYSCALL_AVOIDER ((word_t) 222)
 
 #elif defined(ARCH_ARM64)
 

--- a/src/syscall/sysnums-arm.h
+++ b/src/syscall/sysnums-arm.h
@@ -182,7 +182,6 @@ static const Sysnum sysnums_arm[] = {
 	[ 219 ] = PR_mincore,
 	[ 220 ] = PR_madvise,
 	[ 221 ] = PR_fcntl64,
-	[ 222 ] = PR_void,
 	[ 224 ] = PR_gettid,
 	[ 225 ] = PR_readahead,
 	[ 226 ] = PR_setxattr,


### PR DESCRIPTION
The use of a real syscall number causes problem with seccomp enabled
since we might not get a second chance in sysexit to set the return value from the syscall.

This, along with the use of PROOT_SET_SYSCALL,
was introduced in e675d09b2ce133110afe32ac379868d1691b1fdf.
The comment and the commit message claims that the syscall number must be a valid one.
However, based on local testing (on both an aarch64 kernel and an arm kernel)
it seems that while the 32bit kernel is unhappy about a invalid syscall number
it treats a `-1` from the ptracer as ignoring the syscall just as what we need.
OTOH, the 64bit kernel doesn't seem to care at all and will happily treate the `-2`
as ignoring syscall as well. I have not found any document
about the special treatment of `syscall(-1)` but this is what strace uses.

The original choice of `-2` seems to be because `-1` is used to indicate uninitialized value.
It doesn't seem that this is needed anymore after 63c7f7f66824660408abc06b2b0ea98a00ef8096
and we should be able to use the better supported `-1` for this purpose.