### PR TITLE
Allow the value of AT_HWCAP to be empty

### DIFF
--- a/test/test-carehwcp.sh
+++ b/test/test-carehwcp.sh
@@ -8,8 +8,8 @@ fi
 
 TMP=/tmp/$(mcookie)
 
-${CARE} -o ${TMP}/ env LD_SHOW_AUXV=1 true   | grep '^AT_HWCAP:[[:space:]]*0$'
-${TMP}/re-execute.sh                         | grep '^AT_HWCAP:[[:space:]]*0$'
-${TMP}/re-execute.sh env LD_SHOW_AUXV=1 true | grep '^AT_HWCAP:[[:space:]]*0$'
+${CARE} -o ${TMP}/ env LD_SHOW_AUXV=1 true   | grep '^AT_HWCAP:[[:space:]]*0\?$'
+${TMP}/re-execute.sh                         | grep '^AT_HWCAP:[[:space:]]*0\?$'
+${TMP}/re-execute.sh env LD_SHOW_AUXV=1 true | grep '^AT_HWCAP:[[:space:]]*0\?$'
 
 rm -fr ${TMP}


### PR DESCRIPTION
On ARM the glibc decodes the hwcap into strings similar to that from /proc/cpuinfo.
This means that an value of zero prints an empty string.

With this I see the same test passages on arm, aarch64 and x64 locally. Unfortunately, none of the failures I saw before these looks similar to https://github.com/proot-me/proot/issues/286 though.