### PR TITLE
Error out when trying to set PTRACE_O_TRACESECCOMP under ptrace emulation.

### DIFF
--- a/src/ptrace/ptrace.c
+++ b/src/ptrace/ptrace.c
@@ -258,6 +258,13 @@ int translate_ptrace_exit(Tracee *tracee)
 		break;  /* Restart the ptracee.  */
 
 	case PTRACE_SETOPTIONS:
+		if (data & PTRACE_O_TRACESECCOMP) {
+			/* We don't really support forwarding seccomp traps */
+			note(ptracer, WARNING, INTERNAL,
+			     "ptrace option PTRACE_O_TRACESECCOMP "
+			     "not supported yet");
+			return -EINVAL;
+		}
 		PTRACEE.options = data;
 		return 0;  /* Don't restart the ptracee.  */
 


### PR DESCRIPTION
proot currently does not even try to handle seccomp traps when running
ptrace emulation. Returning an error is better than misleading the ptracer
into expecting seccomp events.

In conjunction with PR #308, this (sort of) fixes test-230f47ch.