### PR TITLE
Fix test-0cf405b0 for newer versions of glibc.

### DIFF
--- a/test/test-0cf405b0.c
+++ b/test/test-0cf405b0.c
@@ -1,12 +1,13 @@
 #include <unistd.h> /* execlp(2), */
-#include <stdlib.h> /* exit(3), */
+#include <stdlib.h> /* exit(3), getenv(3), setenv(3)*/
 #include <string.h> /* strcmp(3), */
 
 int main(int argc, char *argv[])
 {
-	if (argc == 0) //strcmp(argv[0], "/proc/self/exe") == 0)
+	if (getenv("PROC_SELF_EXE") != NULL)
 		exit(EXIT_SUCCESS);
 
+	setenv("PROC_SELF_EXE", "1", 1);
 	execlp("/proc/self/exe", NULL);
 	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Newer versions of glibc apparently enforce argv to contain at least one argument, regardless of what what passed to execlp(). This behavioral change resulted in test-0cf405b0 performing an endless loop.

This commit addresses this problem by setting an environment variable to indicate, whether the execlp() call has already been performed.