### PR TITLE
Add option --no-host-elf to disable mixed execution

### DIFF
--- a/src/cli/proot.c
+++ b/src/cli/proot.c
@@ -143,6 +143,12 @@ static int handle_option_q(Tracee *tracee, const Cli *cli UNUSED, const char *va
 	return 0;
 }
 
+static int handle_option_no_host_elf(Tracee *tracee, const Cli *cli UNUSED, const char *value UNUSED)
+{
+	tracee->no_host_elf = true;
+	return 0;
+}
+
 static int handle_option_w(Tracee *tracee, const Cli *cli UNUSED, const char *value)
 {
 	tracee->fs->cwd = talloc_strdup(tracee->fs, value);

--- a/src/cli/proot.h
+++ b/src/cli/proot.h
@@ -51,6 +51,7 @@ static const char *recommended_su_bindings[] = {
 static int handle_option_r(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_b(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_q(Tracee *tracee, const Cli *cli, const char *value);
+static int handle_option_no_host_elf(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_w(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_v(Tracee *tracee, const Cli *cli, const char *value);
 static int handle_option_V(Tracee *tracee, const Cli *cli, const char *value);
@@ -137,6 +138,15 @@ Copyright (C) 2022 PRoot Developers, licensed under GPL v2 or later.",
 \temulated by QEMU user-mode.  The native execution of host programs\n\
 \tis still effective and the whole host rootfs is bound to\n\
 \t/host-rootfs in the guest environment.",
+	},
+	{ .class = "Regular options",
+	  .arguments = {
+		{ .name = "--no-host-elf", .separator = '\0', .value = NULL },
+		{ .name = NULL, .separator = '\0', .value = NULL } },
+	  .handler = handle_option_no_host_elf,
+	  .description = "Disable the mixed-execution feature.",
+	  .detail = "\tDo not treat ELF executables specially when they appear to be\n\
+\tnative executables of the host system.",
 	},
 	{ .class = "Regular options",
 	  .arguments = {

--- a/src/execve/enter.c
+++ b/src/execve/enter.c
@@ -382,7 +382,7 @@ static int expand_runner(Tracee* tracee, char host_path[PATH_MAX], char user_pat
 
 	/* No need to adjust argv[] if it's a host binary (a.k.a
 	 * mixed-mode).  */
-	if (!is_host_elf(tracee, host_path)) {
+	if (tracee->no_host_elf || !is_host_elf(tracee, host_path)) {
 		ArrayOfXPointers *argv;
 		size_t nb_qemu_args;
 		size_t i;

--- a/src/tracee/tracee.h
+++ b/src/tracee/tracee.h
@@ -204,6 +204,8 @@ typedef struct tracee {
 	 * execve sysexit.  */
 	struct load_info *load_info;
 
+	/* Disable mixed-execution (native host) check */
+	bool no_host_elf;
 
 	/**********************************************************************
 	 * Private but inherited resources                                    *


### PR DESCRIPTION
New option --no-host-elf disables the check to see if the executable being executed is the same ELF machine as the host system. This is to support the case where ELF objects are run under a custom QEMU emulator or LD_LIBRARY_PATH.

Bug: https://github.com/proot-me/proot/issues/343