### PR TITLE
Fix test-25069c12 and test-25069c13 for new kernels.

### DIFF
--- a/test/test-25069c12.c
+++ b/test/test-25069c12.c
@@ -1,14 +1,15 @@
-#include <unistd.h> /* execve(2), */
-#include <stdlib.h> /* exit(3), */
+#include <unistd.h> /* execv(2), */
+#include <stdlib.h> /* exit(3), getenv(3), setenv(3), */
 #include <string.h> /* strcmp(3), */
 
 int main(int argc, char *argv[])
 {
 	char *void_array[] = { NULL };
 
-	if (argc == 0)
+	if (getenv("PROC_SELF_EXE") != NULL)
 		exit(EXIT_SUCCESS);
 
-	execve("/proc/self/exe", void_array, void_array);
+	setenv("PROC_SELF_EXE", "1", 1);
+	execv("/proc/self/exe", void_array);
 	exit(EXIT_FAILURE);
 }

--- a/test/test-25069c13.c
+++ b/test/test-25069c13.c
@@ -1,12 +1,13 @@
-#include <unistd.h> /* execve(2), */
-#include <stdlib.h> /* exit(3), */
+#include <unistd.h> /* execv(2), */
+#include <stdlib.h> /* exit(3), getenv(3), setenv(3), */
 #include <string.h> /* strcmp(3), */
 
 int main(int argc, char *argv[])
 {
-	if (argc == 0)
+	if (getenv("PROC_SELF_EXE") != NULL)
 		exit(EXIT_SUCCESS);
 
-	execve("/proc/self/exe", NULL, NULL);
+	setenv("PROC_SELF_EXE", "1", 1);
+	execv("/proc/self/exe", NULL);
 	exit(EXIT_FAILURE);
 }


### PR DESCRIPTION
Fix both tests in the same vein as [1].  Note that this behavior had been changed by Linux's [2], not by glibc as suggested by [1].

[1] 10dd605103bfc0856ae0247b2c2cc60e3e32489d
[2] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=dcd46d897adb70d63e025f175a00a89797d31a43