### PR TITLE
Fix compiler error when using newer clang versions

### DIFF
--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -44,6 +44,7 @@
 #include "cli/note.h"
 
 #include "compat.h"
+#include "mem.h"
 
 #ifndef __W_STOPCODE
 #define __W_STOPCODE(sig)	((sig) <<8 | 0x7f)


### PR DESCRIPTION
https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16

> Starting with Clang 16, implicit function definitions will be considered an error instead of a warning. The C99 standard dropped support for implicit function definitions, but many compilers continued to accept them for backward compatibility.