### PR TITLE
fix path referrer not a strict subpath of "/proc"

### DIFF
--- a/src/path/path.c
+++ b/src/path/path.c
@@ -419,13 +419,14 @@ int detranslate_path(Tracee *tracee, char path[PATH_MAX], const char t_referrer[
 	/* Is it a symlink?  */
 	if (t_referrer != NULL) {
 		Comparison comparison;
+		Comparison path_comparison;
 
 		sanity_check = false;
 		follow_binding = false;
-
 		/* In some cases bindings have to be resolved.  */
 		comparison = compare_paths("/proc", t_referrer);
-		if (comparison == PATH1_IS_PREFIX) {
+		path_comparison = compare_paths("/proc", path);
+		if (comparison == PATH1_IS_PREFIX && path_comparison != PATHS_ARE_NOT_COMPARABLE) {
 			/* Some links in "/proc" are generated
 			 * dynamically by the kernel.  PRoot has to
 			 * emulate some of them.  */


### PR DESCRIPTION
fix symmetric link in "/proc" not a strict subpath of "proc".
eg: /proc/device-tree -> /sys/firmware/devicetree/base

![20240814162742](https://github.com/user-attachments/assets/d7597d17-9c3a-4787-b4fb-d34d32a6b528)

![20240815144535](https://github.com/user-attachments/assets/da333d3f-3a07-42e5-99d7-eb227389ae9f)

