### PR TITLE
Allow max names of 255 characters

### DIFF
--- a/src/path/canon.c
+++ b/src/path/canon.c
@@ -83,7 +83,7 @@ static inline void pop_component(char *path)
  *
  *     - 0 otherwise.
  */
-static inline Finality next_component(char component[NAME_MAX], const char **cursor)
+static inline Finality next_component(char component[NAME_MAX+1], const char **cursor)
 {
 	const char *start;
 	ptrdiff_t length;
@@ -103,7 +103,7 @@ static inline Finality next_component(char component[NAME_MAX], const char **cur
 		(*cursor)++;
 	length = *cursor - start;
 
-	if (length >= NAME_MAX)
+	if (length > NAME_MAX)
 		return -ENAMETOOLONG;
 
 	/* Extract the component. */
@@ -224,7 +224,7 @@ int canonicalize(Tracee *tracee, const char *user_path, bool deref_final,
 	finality = NOT_FINAL;
 	while (!IS_FINAL(finality)) {
 		Comparison comparison;
-		char component[NAME_MAX];
+		char component[NAME_MAX+1];
 
 		finality = next_component(component, &cursor);
 		status = (int) finality;

--- a/src/path/proc.c
+++ b/src/path/proc.c
@@ -41,7 +41,7 @@
  * to @result.
  */
 Action readlink_proc(const Tracee *tracee, char result[PATH_MAX],
-			const char base[PATH_MAX], const char component[NAME_MAX],
+			const char base[PATH_MAX], const char component[NAME_MAX+1],
 			Comparison comparison)
 {
 	const Tracee *known_tracee;

--- a/src/path/proc.h
+++ b/src/path/proc.h
@@ -37,7 +37,7 @@ typedef enum {
 
 
 extern Action readlink_proc(const Tracee *tracee, char result[PATH_MAX], const char path[PATH_MAX],
-			const char component[NAME_MAX],	Comparison comparison);
+			const char component[NAME_MAX+1],	Comparison comparison);
 
 extern ssize_t readlink_proc2(const Tracee *tracee, char result[PATH_MAX], const char path[PATH_MAX]);
 


### PR DESCRIPTION
This pull request fixes #391. For details related to the bug see there.
For me, it seems to work quite well. I did NOT test it extensively.
I just tried to create the debian package for GOCRYPTFS an this failed before due
to issues related to file name length. Now it works.

In order to allow names of 255 characters, I extended most buffers from [NAME_MAX](255) to [NAME_MAX+1](255+1).
We probably use the buffers for null-terminated filenames, so we need 255 characters + the closing null byte.
