### PR TITLE
Add emulation of the stat family on mknod'd files.

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -37,6 +37,12 @@ typedef unsigned char byte_t;
 
 #define OFFSETOF_STATX_UID 20
 #define OFFSETOF_STATX_GID 24
+#define OFFSETOF_STATX_MODE 28
+#define OFFSETOF_STATX_INO 32
+#define OFFSETOF_STATX_RDEV_MAJOR 128
+#define OFFSETOF_STATX_RDEV_MINOR 132
+#define OFFSETOF_STATX_DEV_MAJOR 136
+#define OFFSETOF_STATX_DEV_MINOR 140
 
 #if !defined(ARCH_X86_64) && !defined(ARCH_ARM_EABI) && !defined(ARCH_X86) && !defined(ARCH_SH4)
 #    if defined(__x86_64__)
@@ -78,8 +84,12 @@ typedef unsigned char byte_t;
 
     #define HOST_ELF_MACHINE {62, 3, 6, 0}
     #define RED_ZONE_SIZE 128
+    #define OFFSETOF_STAT_DEV_32 0
+    #define OFFSETOF_STAT_INO_32 12
+    #define OFFSETOF_STAT_MODE_32 16
     #define OFFSETOF_STAT_UID_32 24
     #define OFFSETOF_STAT_GID_32 28
+    #define OFFSETOF_STAT_RDEV_32 32
 
     #define LOADER_ADDRESS 0x600000000000
     #define HAS_LOADER_32BIT true
@@ -101,8 +111,10 @@ typedef unsigned char byte_t;
     #define user_regs_struct user_regs
     #define HOST_ELF_MACHINE {40, 0};
     #define RED_ZONE_SIZE 0
+    #define OFFSETOF_STAT_MODE_32 0
     #define OFFSETOF_STAT_UID_32 0
     #define OFFSETOF_STAT_GID_32 0
+    #define OFFSETOF_STAT_RDEV_32 0
     #define EM_ARM 40
 
     #define LOADER_ADDRESS 0x10000000
@@ -125,8 +137,10 @@ typedef unsigned char byte_t;
 
     #define HOST_ELF_MACHINE {183, 0};
     #define RED_ZONE_SIZE 0
+    #define OFFSETOF_STAT_MODE_32 0
     #define OFFSETOF_STAT_UID_32 0
     #define OFFSETOF_STAT_GID_32 0
+    #define OFFSETOF_STAT_RDEV_32 0
 
     #define LOADER_ADDRESS     0x2000000000
     #define EXEC_PIC_ADDRESS   0x3000000000
@@ -145,8 +159,10 @@ typedef unsigned char byte_t;
 
     #define HOST_ELF_MACHINE {3, 6, 0};
     #define RED_ZONE_SIZE 0
+    #define OFFSETOF_STAT_MODE_32 0
     #define OFFSETOF_STAT_UID_32 0
     #define OFFSETOF_STAT_GID_32 0
+    #define OFFSETOF_STAT_RDEV_32 0
 
     #define LOADER_ADDRESS 0xa0000000
     #define LOADER_ARCH_CFLAGS -mregparm=3
@@ -166,8 +182,10 @@ typedef unsigned char byte_t;
     #define user_regs_struct pt_regs
     #define HOST_ELF_MACHINE {42, 0};
     #define RED_ZONE_SIZE 0
+    #define OFFSETOF_STAT_MODE_32 0
     #define OFFSETOF_STAT_UID_32 0
     #define OFFSETOF_STAT_GID_32 0
+    #define OFFSETOF_STAT_RDEV_32 0
     #define NO_MISALIGNED_ACCESS 1
 
 #else

--- a/src/tracee/abi.h
+++ b/src/tracee/abi.h
@@ -107,6 +107,39 @@ static inline size_t sizeof_word(const Tracee *tracee)
 #include <sys/stat.h>
 
 /**
+ * Return the offset of the 'dev' field in a 'stat' structure
+ * according to the ABI currently used by the given @tracee.
+ */
+static inline off_t offsetof_stat_dev(const Tracee *tracee)
+{
+	return (is_32on64_mode(tracee)
+		? OFFSETOF_STAT_DEV_32
+		: offsetof(struct stat, st_dev));
+}
+
+/**
+ * Return the offset of the 'ino' field in a 'stat' structure
+ * according to the ABI currently used by the given @tracee.
+ */
+static inline off_t offsetof_stat_ino(const Tracee *tracee)
+{
+	return (is_32on64_mode(tracee)
+		? OFFSETOF_STAT_INO_32
+		: offsetof(struct stat, st_ino));
+}
+
+/**
+ * Return the offset of the 'mode' field in a 'stat' structure
+ * according to the ABI currently used by the given @tracee.
+ */
+static inline off_t offsetof_stat_mode(const Tracee *tracee)
+{
+	return (is_32on64_mode(tracee)
+		? OFFSETOF_STAT_MODE_32
+		: offsetof(struct stat, st_mode));
+}
+
+/**
  * Return the offset of the 'uid' field in a 'stat' structure
  * according to the ABI currently used by the given @tracee.
  */
@@ -126,6 +159,17 @@ static inline off_t offsetof_stat_gid(const Tracee *tracee)
 	return (is_32on64_mode(tracee)
 		? OFFSETOF_STAT_GID_32
 		: offsetof(struct stat, st_gid));
+}
+
+/**
+ * Return the offset of the 'rdev' field in a 'stat' structure
+ * according to the ABI currently used by the given @tracee.
+ */
+static inline off_t offsetof_stat_rdev(const Tracee *tracee)
+{
+	return (is_32on64_mode(tracee)
+		? OFFSETOF_STAT_RDEV_32
+		: offsetof(struct stat, st_rdev));
 }
 
 #endif /* TRACEE_ABI_H */


### PR DESCRIPTION
I'm trying to run debootstrap under proot, and it uses mknod(1) (with `-m`) to create the device nodes it needs.

- mknod(1) [tries][0] to use lchmod(3) on the device node after creating it
- glibc [implements][1] lchmod in terms of fchmodat(3)
- fchmodat(3) has to [use][2] fchmodat2(2), because fchmodat(2) doesn't accept `AT_SYMLINK_NOFOLLOW`
- fchmodat2(2) is [not][3] supported by proot, so we call `fchmodat_fallback`
- fchmodat_fallback [tries][4] to open the file (with `O_PATH`)
- Because we didn't actually create the file, or otherwise remember it, we return `ENOENT`.

My inclination would be to fix this by emulating the device node's "deviceness" for the purposes of stat:

- mknod(2) would creat a regular file instead, and keep it around in a table (indexed by its `st_dev` and `st_ino`)
- fstatat64, newfstatat, etc. would look the file up in the table, and replace its `st_mode` and `st_rdev` if it matched.

This is enough to get mknod(1) to work, and stat(1) to report the file's specialness:

```
$ ./src/proot -S / sh -c 'mknod -m 123 foo c 6 1 && stat foo; rm foo'
  File: foo
  Size: 0               Blocks: 1          IO Block: 131072 character special file
Device: 0,41    Inode: 5715306     Links: 1     Device type: 6,1
Access: (0123/c--x-w--wx)  Uid: (    0/    root)   Gid: (    0/    root)
Access: 2025-02-06 17:05:54.528052661 -0600
Modify: 2025-02-06 17:05:54.528052661 -0600
Change: 2025-02-06 17:05:54.528052661 -0600
 Birth: 2025-02-06 17:05:54.528052661 -0600
```

[0]: https://git.savannah.gnu.org/cgit/coreutils.git/tree/src/mknod.c?id=v9.5#n273
[1]: https://sourceware.org/git/?p=glibc.git;a=blob;f=io/lchmod.c;h=7894038afa372d0a53d46df2a53c26a4b5577a3d;hb=cdb0800022110bc68a033944f09e501be5bd72d7#l24
[2]: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/fchmodat.c;h=dd1fa5db86bde99fe3eb4804b06c5adf11914b94;hb=cdb0800022110bc68a033944f09e501be5bd72d7#l99
[3]: https://github.com/proot-me/proot/issues/387
[4]: https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/unix/sysv/linux/fchmodat.c;h=dd1fa5db86bde99fe3eb4804b06c5adf11914b94;hb=cdb0800022110bc68a033944f09e501be5bd72d7#l40