### PR TITLE
tracee: Add missing import

### DIFF
--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -35,6 +35,7 @@
 
 #include "tracee/tracee.h"
 #include "tracee/reg.h"
+#include "tracee/mem.h"
 #include "path/binding.h"
 #include "syscall/sysnum.h"
 #include "tracee/event.h"


### PR DESCRIPTION
`mem.h` import is missing from `tracee.c`, preventing `proot` from being successfully built.

This can be reproduced using the following Dockerfile:

```
FROM chainguard/wolfi-base

RUN \
  apk add clang make curl python3 pkgconf git \
  && cd /tmp \
  && curl -SsL https://www.samba.org/ftp/talloc/talloc-2.4.3.tar.gz | tar -xz \
  && cd talloc-* \
  && ./configure build  --disable-rpath --disable-python \
  && mkdir -p /usr/local/lib /usr/local/include /usr/lib/pkgconfig \
  && ar rcs /usr/local/lib/libtalloc.a bin/default/talloc*.o \
  && cp -f talloc.h /usr/local/include \
  && cp bin/default/talloc.pc /usr/lib/pkgconfig/ \
  && git clone https://github.com/proot-me/proot \
  && cd proot \
  && make -C src loader.elf loader-m32.elf build.h \
  && make -C src proot
```

This will result in the following error:

```
7.305   CC      tracee/tracee.o
7.349 ./tracee/tracee.c: In function 'new_child':
7.349 ./tracee/tracee.c:409:31: error: implicit declaration of function 'peek_word' [-Wimplicit-function-declaration]
7.349   409 |                 clone_flags = peek_word(parent, peek_reg(parent, CURRENT, SYSARG_1));
7.349       |                               ^~~~~~~~~
7.354 make: *** [GNUmakefile:192: tracee/tracee.o] Error 1
7.354 make: Leaving directory '/proot/src'
```

To resolve the issue, add `tracee/mem.h` import to `tracee/tracee.c`.