### PR TITLE
fix(tracee): include mem.h to declare peek_word in tracee.c

### DIFF
--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -33,6 +33,7 @@
 #include <errno.h>      /* E*, */
 #include <inttypes.h>   /* PRI*, */
 
+#include "mem.h"
 #include "tracee/tracee.h"
 #include "tracee/reg.h"
 #include "path/binding.h"


### PR DESCRIPTION
#include "mem.h" in tracee.c to fix implicit declaration of peek_word, resolving compilation errors.

```
./tracee/tracee.c: In function ‘new_child’:
./tracee/tracee.c:409:31: error: implicit declaration of function ‘peek_word’ [-Wimplicit-function-declaration]
  409 |                 clone_flags = peek_word(parent, peek_reg(parent, CURRENT, SYSARG_1));
      |                               ^~~~~~~~~
make: *** [GNUmakefile:191: tracee/tracee.o] 
```

Host OS Arch
gcc (GCC) 15.1.1 20250425
