### PR TITLE
feat: Create Node.js wrapper for proot

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,25 @@
+# CI/CD and project config
+.github/
+.gitlab-ci.yml
+.dockerignore
+sonar-project.properties
+.mailmap
+AUTHORS
+HACKING.rst
+ISSUE_TEMPLATE
+
+# Documentation
+doc/
+
+# Test files
+test/
+
+# Source build artifacts (the src/proot binary IS needed)
+src/**/*.o
+src/loader/loader
+src/loader/loader-m32
+src/cli/care
+src/cli/care.o
+
+# Vagrant config
+vagrant/

--- a/example.js
+++ b/example.js
@@ -1,0 +1,30 @@
+const proot = require('./index');
+const fs = require('fs');
+const path = require('path');
+
+const testFile = 'test-file.txt';
+const absoluteTestFile = path.resolve(__dirname, testFile);
+const boundPath = '/tmp/bound-file.txt'; // Using /tmp directory
+
+// 1. Create a dummy file.
+fs.writeFileSync(testFile, 'This is a test file.');
+console.log(`Created a temporary file: ${absoluteTestFile}`);
+
+
+console.log(`\n--- Running proot to bind '${absoluteTestFile}' to '${boundPath}' and list it ---`);
+const args = ['-b', `${absoluteTestFile}:${boundPath}`, 'ls', '-l', boundPath];
+const prootProcess = proot(args);
+
+prootProcess.on('exit', (code) => {
+  console.log(`\nProot process exited with code ${code}.`);
+
+  // Clean up the dummy file.
+  fs.unlinkSync(testFile);
+  console.log(`Cleaned up temporary file: ${testFile}`);
+
+  if (code === 0) {
+    console.log('\n✅ Example ran successfully!');
+  } else {
+    console.error('\n❌ Example failed. The proot command returned a non-zero exit code.');
+  }
+});

--- a/index.js
+++ b/index.js
@@ -1,0 +1,28 @@
+const { spawn } = require('child_process');
+const path = require('path');
+
+// Resolve the path to the proot executable, which should be in src/ after compilation.
+const prootExecutable = path.resolve(__dirname, 'src', 'proot');
+
+/**
+ * Executes a command within the proot environment.
+ * @param {string[]} args - An array of arguments to pass to proot.
+ * @returns {import('child_process').ChildProcess} The spawned child process.
+ */
+function proot(args) {
+  if (!Array.isArray(args)) {
+    throw new Error('Arguments must be provided as an array of strings.');
+  }
+
+  const child = spawn(prootExecutable, args, {
+    stdio: 'inherit' // Pipe stdin, stdout, stderr to the parent process
+  });
+
+  child.on('error', (err) => {
+    console.error('Failed to start proot process:', err);
+  });
+
+  return child;
+}
+
+module.exports = proot;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "@soymaycol/proot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@soymaycol/proot",
+      "version": "1.0.0",
+      "hasInstallScript": true,
+      "license": "GPL-2.0-or-later"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@soymaycol/proot",
+  "version": "1.0.0",
+  "description": "A Node.js wrapper for proot, allowing chroot, mount --bind, and binfmt_misc without privilege/setup.",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "example.js",
+    "README.rst",
+    "CHANGELOG.rst",
+    "COPYING",
+    "src/"
+  ],
+  "scripts": {
+    "install": "make -C src proot",
+    "test": "node example.js"
+  },
+  "author": {
+    "name": "SoyMaycol",
+    "url": "https://github.com/SoySapo6"
+  },
+  "license": "GPL-2.0-or-later",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SoySapo6/proot.git"
+  },
+  "keywords": [
+    "proot",
+    "chroot",
+    "mount",
+    "binfmt_misc",
+    "sandbox",
+    "jail"
+  ]
+}

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -35,6 +35,7 @@
 
 #include "tracee/tracee.h"
 #include "tracee/reg.h"
+#include "tracee/mem.h"
 #include "path/binding.h"
 #include "syscall/sysnum.h"
 #include "tracee/event.h"


### PR DESCRIPTION
This commit introduces a Node.js wrapper for the `proot` utility, allowing it to be used as an npm module. The original C project could not be converted to pure Node.js due to its use of low-level system calls (`ptrace`).

This wrapper accomplishes the user's goal by:
- Creating a `package.json` to define the `@soymaycol/proot` module.
- Adding an `npm install` script that compiles the original `proot` C code into a binary.
- Providing an `index.js` file that exports a function to execute the `proot` binary with specified arguments.
- Including an `example.js` to demonstrate usage and serve as a test.
- Configuring `.npmignore` to ensure a clean and minimal published package.

The author is set to "SoyMaycol" as requested.