### PR TITLE
CI: enable tests in Ubuntu 26

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,14 +9,15 @@ on:
 
 jobs:
   build:
-    name: "${{ matrix.SECCOMP == '1' && 'seccomp' || 'no-seccomp' }}"
-    runs-on: ubuntu-latest
+    name: "${{ matrix.SECCOMP == '1' && 'seccomp' || 'no-seccomp' }} | ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
     env:
       BUILD_WRAPPER_OUT_DIR: tmp
     strategy:
       fail-fast: false
       matrix:
         SECCOMP: [ 0, 1 ]
+        os: [ubuntu-24.04, ubuntu-26.04]
 
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
@@ -29,7 +30,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq clang-tools-12 curl gdb lcov libarchive-dev libtalloc-dev sloccount strace swig uthash-dev python3-dev lzop
+          sudo apt-get install -qq clang-tools curl gdb lcov libarchive-dev libtalloc-dev sloccount strace swig uthash-dev python3-dev lzop
 
       - name: Gather analytics
         run: sloccount --details .

--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -33,6 +33,7 @@
 #include <errno.h>      /* E*, */
 #include <inttypes.h>   /* PRI*, */
 
+#include "tracee/mem.h"
 #include "tracee/tracee.h"
 #include "tracee/reg.h"
 #include "path/binding.h"


### PR DESCRIPTION
This runs CI tests in both ubuntu 24 (currently latest) and 26: there seem to be much more failures in 26.

PS: I am getting return error 182 from proot in 26 unless PROOT_NO_SECCOMP=1 is set.