### PR TITLE
Fix build issue in tracee

### DIFF
--- a/src/tracee/tracee.c
+++ b/src/tracee/tracee.c
@@ -35,6 +35,7 @@
 
 #include "tracee/tracee.h"
 #include "tracee/reg.h"
+#include "tracee/mem.h"
 #include "path/binding.h"
 #include "syscall/sysnum.h"
 #include "tracee/event.h"


### PR DESCRIPTION
Fix build issue

error:

```
./tracee/tracee.c:409:31: error: implicit declaration of function ‘peek_word’ [-Wimplicit-function-declaration]
  409 |                 clone_flags = peek_word(parent, peek_reg(parent, CURRENT, SYSARG_1));
      |                               ^~~~~~~~~
make: *** [GNUmakefile:192: tracee/tracee.o] Error 1
make: Leaving directory '/home/dante/Desktop/proot/src'
```