### PR TITLE
fix: don't embed a bare '-' when no git version info is available

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -123,7 +123,7 @@ GIT_VERSION := $(shell git describe --tags --always 2>/dev/null)
 
 GIT_COMMIT := $(shell git rev-parse --short=8 HEAD 2>/dev/null)
 
-VERSION = $(GIT_VERSION)-$(GIT_COMMIT)
+VERSION = $(if $(or $(GIT_VERSION),$(GIT_COMMIT)),$(GIT_VERSION)-$(GIT_COMMIT))
 
 CHECK_VERSION = if [ ! -z "$(VERSION)" ]; \
                 then /bin/echo -e "\#undef VERSION\n\#define VERSION \"$(VERSION)\""; \


### PR DESCRIPTION
## Why

`proot --version` can print a bare `-` where the version should be (see #409). Root cause: `VERSION = $(GIT_VERSION)-$(GIT_COMMIT)` is always non-empty even when both pieces are empty (no `.git`, or a source tarball build), because the literal `-` separator survives. `CHECK_VERSION`'s `[ ! -z ... ]` check then treats that as a real version and writes `#define VERSION "-"` into `build.h`, which permanently shadows the correct doc-generated fallback in `src/cli/proot.h` (`#ifndef VERSION` never triggers).

## What this does

`VERSION` is now only non-empty when at least one of `GIT_VERSION`/`GIT_COMMIT` actually resolved to something, using `$(if $(or ...),...)`. When neither resolves, `build.h` omits the `#define` entirely and the `cli/proot.h` fallback takes over as intended — matching the gnulib `git-version-gen` pattern this Makefile is otherwise already following.

Based on `release/v5.4.1` since it builds directly on the version-derivation fix already in that branch (same lines).

## Verification

Confirmed with a minimal standalone Makefile reproducing the exact logic: with both inputs empty, `VERSION` now evaluates to nothing and no `#define VERSION` line is emitted (previously emitted `#define VERSION "-"`).

fixes: https://github.com/proot-me/proot/issues/409