### PR TITLE
fix(compat): define user_regs_struct/user_fpregs_struct fallbacks for aarch64

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -259,4 +259,41 @@
 #define NT_ARM_SYSTEM_CALL		0x404
 #endif
 
+/* Some older glibc (e.g. 2.17, as shipped by RHEL/CentOS 7's initial
+ * aarch64 port) never added struct user_regs_struct as a source
+ * compatibility alias for the kernel's struct user_pt_regs: the name
+ * is forward-declared by <sys/user.h> but never given a member list,
+ * so it stays an incomplete type and any use of it fails to compile
+ * ("array type has incomplete element type", "incomplete type is not
+ * allowed", ...).  Provide it ourselves here, laid out exactly like
+ * the kernel ABI (arch/arm64/include/uapi/asm/ptrace.h), for the
+ * glibc versions that need it.  */
+#include <sys/user.h>
+#if defined(__aarch64__) && defined(__GLIBC__)
+#if !__GLIBC_PREREQ(2, 24)
+struct user_regs_struct {
+    unsigned long long regs[31];
+    unsigned long long sp;
+    unsigned long long pc;
+    unsigned long long pstate;
+};
+#endif
+#endif
+
+/* Unlike struct user_regs_struct above, glibc has never defined
+ * struct user_fpregs_struct for aarch64 (confirmed missing as of
+ * glibc 2.39): the kernel's FP/SIMD state has always only had a
+ * name of its own, struct user_fpsimd_state.  Provide the x86-style
+ * alias ourselves, laid out exactly like the kernel ABI (see
+ * arch/arm64/include/uapi/asm/ptrace.h), so this doesn't depend on
+ * a glibc version ever adding it.  */
+#if defined(__aarch64__)
+struct user_fpregs_struct {
+    unsigned __int128 vregs[32];
+    unsigned int fpsr;
+    unsigned int fpcr;
+    unsigned int __reserved[2];
+};
+#endif
+
 #endif				/* COMPAT_H */

--- a/src/compat.h
+++ b/src/compat.h
@@ -259,6 +259,15 @@
 #define NT_ARM_SYSTEM_CALL		0x404
 #endif
 
+/* compat.h is also pulled in by the freestanding, -nostdlib loader
+ * build (see src/GNUmakefile's build_loader), which has no libc
+ * available at all -- <sys/user.h> may not even exist there (e.g. no
+ * 32-bit multilib headers for the m32 loader). The register-transfer
+ * structs below are only ever needed by hosted code that does ptrace
+ * (tracee.h / ptrace.c); the loader never touches them. Skip this
+ * whole block for freestanding translation units.  */
+#if !defined(__STDC_HOSTED__) || __STDC_HOSTED__
+
 /* Some older glibc (e.g. 2.17, as shipped by RHEL/CentOS 7's initial
  * aarch64 port) never added struct user_regs_struct as a source
  * compatibility alias for the kernel's struct user_pt_regs: the name
@@ -295,5 +304,7 @@ struct user_fpregs_struct {
     unsigned int __reserved[2];
 };
 #endif
+
+#endif				/* !defined(__STDC_HOSTED__) || __STDC_HOSTED__ */
 
 #endif				/* COMPAT_H */


### PR DESCRIPTION
## Why

#186 reports proot failing to build on RHEL/CentOS 7 aarch64: `struct user_regs_struct` is an incomplete type, because glibc's `<sys/user.h>` for aarch64 only pulls in the kernel's `<asm/ptrace.h>` and never declares that struct name itself — some glibc builds add it as a compatibility alias for the kernel's `struct user_pt_regs`, some don't.

Reproduced against the real environment in Docker (`arm64v8/centos:7`, glibc 2.17) and confirmed the exact reported error. This isn't a general "older glibc lacks it" story, though: mainline upstream glibc has defined `struct user_regs_struct` for aarch64 since **glibc 2.20 (2014)**, the same release aarch64 support was merged from `ports/` into mainline — confirmed by checking the tagged `glibc-2.20` and `glibc-2.23` source directly ([`sysdeps/unix/sysv/linux/aarch64/sys/user.h`](https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/aarch64/sys/user.h)). RHEL/CentOS 7 ships a heavily patched/backported glibc that self-reports as 2.17 — it added aarch64 as a late "alternative architecture," and its patch queue evidently never picked up this specific bit of upstream aarch64 code. It's a RHEL7-fork-specific gap, not an old-glibc-in-general one.

Fixing that surfaced a second, deeper gap the original report never reached: `struct user_fpregs_struct` (used in `ptrace.c`'s `PTRACE_GETFPREGS`/`SETFPREGS` emulation) is *also* incomplete for aarch64 — and unlike the general-purpose-registers struct, **this one is still missing as of current glibc (2.39, Ubuntu 24.04)**. It's not RHEL7/EOL-specific at all; proot currently can't build `ptrace.c` on any aarch64 glibc system, old or new. The project's CI only builds x86_64, so this has been silently broken the whole time. Confirmed why: glibc's own name for this struct on aarch64 is [`struct user_fpsimd_struct`](https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/aarch64/sys/user.h), not `user_fpregs_struct` — the x86-style name `ptrace.c` actually references has never existed in glibc for aarch64, under any version.

## What this does

Two separate fallback definitions in `src/compat.h`, both laid out exactly like the real kernel ABI (`struct user_pt_regs` / `struct user_fpsimd_state` in [`arch/arm64/include/uapi/asm/ptrace.h`](https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/ptrace.h), cross-checked against the actual kernel-headers package in the test containers):

- `struct user_regs_struct` — only defined when `__GLIBC_PREREQ(2, 24)` isn't satisfied. This threshold doesn't correspond to when upstream glibc actually added the struct (2.20, per above) — it's just a safe, conservative cutoff: RHEL7 self-reports as 2.17 (< 2.24, gets the fallback) and every other distro shipping aarch64 today is well past 2.24 anyway (uses its own, already-correct definition).
- `struct user_fpregs_struct` — always defined for `__aarch64__`, since no glibc version, and no libc at all, provides that name.

`ptrace.c` only ever touches these types through `sizeof()`/`memcpy()`/raw `ptrace()` calls, never named-field access, so matching size and layout (not exact field names) is what correctness actually depends on here.

Based on `release/v5.4.1`.

## Verification

All done against real toolchains in Docker (`--platform linux/arm64`), not guessed:

- `arm64v8/centos:7` (glibc 2.17): reproduced the original `tracee.o` failure, confirmed the `user_regs_struct` fix resolves it, build proceeds to `ptrace.o`.
- Confirmed the upstream glibc version boundary directly against the `glibc-2.20`/`glibc-2.23` tagged source (see above) rather than inferring it from distro package versions.
- `ubuntu:24.04` (glibc 2.39) and `debian:12` (2.36): confirmed `user_fpregs_struct` is independently incomplete here too.
- Full `make loader.elf build.h proot` on `ubuntu:24.04` aarch64 with both fixes in place: builds clean end-to-end, links, and the resulting `proot` binary runs.
- `alpine:latest` (musl): confirmed musl also lacks `user_fpregs_struct`, so the fallback is libc-agnostic (guarded only on `__aarch64__`, not `__GLIBC__`) — and confirmed musl already provides a complete `user_regs_struct`, so that fallback correctly stays glibc-only.

## References

- Kernel ABI: [`arch/arm64/include/uapi/asm/ptrace.h`](https://github.com/torvalds/linux/blob/master/arch/arm64/include/uapi/asm/ptrace.h) — `struct user_pt_regs`, `struct user_fpsimd_state`
- glibc aarch64 header: [`sysdeps/unix/sysv/linux/aarch64/sys/user.h`](https://github.com/bminor/glibc/blob/master/sysdeps/unix/sysv/linux/aarch64/sys/user.h) — `struct user_regs_struct`, `struct user_fpsimd_struct`

fixes: https://github.com/proot-me/proot/issues/186
