### PR TITLE
fix(build): fail with a clear message when pkg-config can't find talloc

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -22,6 +22,20 @@ HAS_PYTHON_CONFIG := $(shell ${PYTHON}-config --ldflags ${PYTHON_EMBED} 2>/dev/n
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../lib/uthash/include
 CFLAGS   += -g -Wall -Wextra -O2
+
+# pkg-config silently returns an empty string for --cflags/--libs when it
+# can't find talloc.pc, which used to surface much later and much more
+# confusingly as "undefined reference to talloc_*" at link time (see
+# https://github.com/proot-me/proot/issues/233). Fail here instead, with
+# a message that points at the actual problem.
+ifeq ($(shell pkg-config --exists talloc && echo yes),)
+$(error talloc development files not found by pkg-config. Install the \
+talloc headers package for your distribution (e.g. libtalloc-dev on \
+Debian/Ubuntu, libtalloc-devel on Fedora/RHEL/CentOS) and make sure \
+pkg-config can find talloc.pc (check the PKG_CONFIG_PATH environment \
+variable if it's installed in a non-standard location))
+endif
+
 CFLAGS   += $(shell pkg-config --cflags talloc)
 LDFLAGS  += -Wl,-z,noexecstack
 LDFLAGS  += $(shell pkg-config --libs talloc)


### PR DESCRIPTION
## Why

#233 reports a build failure with "undefined references to talloc" despite talloc being present on the system. Looking at the actual link line (`$(LD) -o $@ $^ $(LDFLAGS)`, with `-ltalloc` coming from `pkg-config --libs talloc` inside `LDFLAGS`), objects already come before the library on the command line — the correct order for GNU ld — so this isn't a link-order bug. The maintainer's own comment on that thread suspected a missing/broken system package, and nobody ever confirmed a root cause with actual `pkg-config --libs talloc` output from the failing system.

I don't want to ship a guess at a bug I can't reproduce. What I can fix responsibly: `pkg-config --cflags`/`--libs` silently return an empty string when `talloc.pc` can't be found, so if that's what actually happened, the failure surfaces far downstream as a cryptic "undefined reference" at link time with zero indication of the real cause.

## What this does

Checks `pkg-config --exists talloc` upfront and fails immediately with an actionable message (which package to install per distro family, and to check `PKG_CONFIG_PATH` if talloc is in a non-standard location) instead of silently proceeding with empty flags.

Based on `release/v5.4.1`.

## Verification

Tested both paths in a clean Ubuntu 24.04 container:
- Without `libtalloc-dev` installed: `make -n build.h` now stops immediately with the new error message, at `GNUmakefile:32`.
- With `libtalloc-dev` installed: build proceeds normally, `CFLAGS` still picks up `pkg-config --cflags talloc` as before.

fixes: https://github.com/proot-me/proot/issues/233