### PR TITLE
fix(release): fix the actual -static build that the v5.4.1 release run failed on

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -qq libarchive-dev libtalloc-dev pkg-config swig uthash-dev python3-dev lzop
+          sudo apt-get install -qq libarchive-dev libtalloc-dev pkg-config swig uthash-dev lzop g++
 
       - name: Build static proot and care binaries
         run: |

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -40,27 +40,6 @@ CFLAGS   += $(shell pkg-config --cflags talloc)
 LDFLAGS  += -Wl,-z,noexecstack
 LDFLAGS  += $(shell pkg-config --libs talloc)
 
-# A plain `pkg-config --libs` only lists libarchive itself; when linking
-# statically (LDFLAGS containing -static, as the release build does) its
-# own transitive dependencies (nettle, lzma, zstd, ...) need pulling in
-# too, which only the --static form of pkg-config includes.
-#
-# That's not the whole story either: Ubuntu's libarchive.pc hardcodes
-# -lxml2 directly in its own Libs.private instead of declaring a proper
-# Requires.private: libxml-2.0, so pkg-config has no way to know it
-# should also recurse into libxml-2.0's *own* static dependencies (ICU,
-# in particular) -- those have to be pulled in by hand.
-#
-# One more wrinkle: ICU is itself a C++ library (uses std::mutex,
-# RTTI, exceptions, ...), but care links via plain gcc (CC/LD above),
-# not g++, so libstdc++ doesn't get pulled in automatically the way it
-# would for a real C++ link. Add it explicitly.
-#
-# None of this is guaranteed to come out in an order plain left-to-right
-# static linking can resolve in one pass, so wrap the lot in
-# --start-group/--end-group to let ld re-scan until everything resolves,
-# and add -lm/-lstdc++ explicitly since they're needed but not always
-# declared by the .pc files above.
 ifneq ($(findstring -static,$(LDFLAGS)),)
 CARE_LDFLAGS  = -Wl,--start-group $(shell pkg-config --libs --static libarchive) \
                 $(shell pkg-config --exists libxml-2.0 && pkg-config --libs --static libxml-2.0) \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -40,7 +40,34 @@ CFLAGS   += $(shell pkg-config --cflags talloc)
 LDFLAGS  += -Wl,-z,noexecstack
 LDFLAGS  += $(shell pkg-config --libs talloc)
 
+# A plain `pkg-config --libs` only lists libarchive itself; when linking
+# statically (LDFLAGS containing -static, as the release build does) its
+# own transitive dependencies (nettle, lzma, zstd, ...) need pulling in
+# too, which only the --static form of pkg-config includes.
+#
+# That's not the whole story either: Ubuntu's libarchive.pc hardcodes
+# -lxml2 directly in its own Libs.private instead of declaring a proper
+# Requires.private: libxml-2.0, so pkg-config has no way to know it
+# should also recurse into libxml-2.0's *own* static dependencies (ICU,
+# in particular) -- those have to be pulled in by hand.
+#
+# One more wrinkle: ICU is itself a C++ library (uses std::mutex,
+# RTTI, exceptions, ...), but care links via plain gcc (CC/LD above),
+# not g++, so libstdc++ doesn't get pulled in automatically the way it
+# would for a real C++ link. Add it explicitly.
+#
+# None of this is guaranteed to come out in an order plain left-to-right
+# static linking can resolve in one pass, so wrap the lot in
+# --start-group/--end-group to let ld re-scan until everything resolves,
+# and add -lm/-lstdc++ explicitly since they're needed but not always
+# declared by the .pc files above.
+ifneq ($(findstring -static,$(LDFLAGS)),)
+CARE_LDFLAGS  = -Wl,--start-group $(shell pkg-config --libs --static libarchive) \
+                $(shell pkg-config --exists libxml-2.0 && pkg-config --libs --static libxml-2.0) \
+                -lm -lstdc++ -Wl,--end-group
+else
 CARE_LDFLAGS  = $(shell pkg-config --libs libarchive)
+endif
 
 OBJECTS += \
 	cli/cli.o		\


### PR DESCRIPTION
## Why

Publishing v5.4.1 triggered \`release.yml\` for the first time, and it failed — no assets got attached to the release. None of the CI checks on #425 caught this because nothing else builds \`-static\`; the failure only shows up when actually linking statically, which only \`release.yml\` does.

Two independent problems, found by actually reproducing the exact failing recipe in Docker:

**1. \`proot\`'s static link failed outright.** \`release.yml\` installs \`python3-dev\` alongside \`swig\`, which enables proot's optional Python extension. Ubuntu's static \`libpython3.12.a\` has its own unresolved dependencies (zlib, bundled crypto internals) that never get linked in for a \`-static\` build. The historical GitLab static-build job never installed \`python3-dev\` for exactly this reason — it just never hit the combination.

**2. \`care\`'s static link failed for a deeper reason.** \`CARE_LDFLAGS\` was a plain \`pkg-config --libs libarchive\`, which only lists libarchive itself — statically linking needs the \`--static\` form to pull in transitive deps (nettle, lzma, zstd, ...). Even that's not the whole story: Ubuntu's \`libarchive.pc\` hardcodes \`-lxml2\` directly instead of declaring a proper \`Requires.private\`, so pkg-config has no way to know \`libxml-2.0\`'s *own* static deps (ICU) are needed too — and ICU is itself a C++ library needing \`libstdc++\`, which \`care\` never picks up since it links via plain \`gcc\`, not \`g++\`.

## What this does

- Drop \`python3-dev\` from \`release.yml\`'s dependency install.
- \`CARE_LDFLAGS\` uses \`pkg-config --libs --static libarchive\` when \`-static\` is in \`LDFLAGS\`, plus \`libxml-2.0\`'s own static libs pulled in explicitly (guarded on \`pkg-config --exists\`), wrapped in \`-Wl,--start-group\`/\`--end-group\` since the combined list isn't in a left-to-right-resolvable order, plus explicit \`-lm\`/\`-lstdc++\`.
- Add \`g++\` to \`release.yml\` so \`libstdc++.a\` is actually present to link against.

## Verification

Ran the *exact* \`release.yml\` recipe end-to-end (version-match checks, static build, embedded-version-string verification, \`SHA256SUMS\` generation) in a clean \`ubuntu:24.04\` container, matching the real runner: both \`proot\` and \`care\` now build, link, and run correctly as fully static binaries (\`not a dynamic executable\`). Only the standard, expected glibc static-linking NSS warnings remain (\`dlopen\`/\`getgrnam_r\`/\`getaddrinfo\`/\`gethostbyname\`/\`getpwnam_r\`), no errors. Embedded version string correctly resolves to \`v5.4.1-<hash>\`.

## After this merges

The \`v5.4.1\` tag/release already exist but have no assets. Once this is in, the tag needs to move to the new commit and the release workflow needs re-triggering to actually publish the binaries — flagging that as a follow-up step, not doing it in this PR.