### PR TITLE
fix: make pkg-config and ld respect CROSS_COMPILE

### DIFF
--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -5,15 +5,17 @@
 VPATH := $(dir $(lastword $(MAKEFILE_LIST)))
 SRC    = $(dir $(firstword $(MAKEFILE_LIST)))
 
-GIT      = git
-RM       = rm
-INSTALL  = install
-CC       = $(CROSS_COMPILE)gcc
-LD       = $(CC)
-STRIP    = $(CROSS_COMPILE)strip
-OBJCOPY  = $(CROSS_COMPILE)objcopy
-OBJDUMP  = $(CROSS_COMPILE)objdump
-PYTHON   = python3
+GIT        = git
+RM         = rm
+INSTALL    = install
+CC         = $(CROSS_COMPILE)gcc
+LD         = $(CC)
+LD_CMD     = $(CROSS_COMPILE)ld
+STRIP      = $(CROSS_COMPILE)strip
+OBJCOPY    = $(CROSS_COMPILE)objcopy
+OBJDUMP    = $(CROSS_COMPILE)objdump
+PKG_CONFIG = $(CROSS_COMPILE)pkg-config
+PYTHON     = python3
 
 HAS_SWIG := $(shell swig -version 2>/dev/null)
 PYTHON_MAJOR_VERSION = $(shell ${PYTHON} -c "import sys; print(sys.version_info.major)" 2>/dev/null)
@@ -22,13 +24,12 @@ HAS_PYTHON_CONFIG := $(shell ${PYTHON}-config --ldflags ${PYTHON_EMBED} 2>/dev/n
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../lib/uthash/include
 CFLAGS   += -g -Wall -Wextra -O2
-
 # pkg-config silently returns an empty string for --cflags/--libs when it
 # can't find talloc.pc, which used to surface much later and much more
 # confusingly as "undefined reference to talloc_*" at link time (see
 # https://github.com/proot-me/proot/issues/233). Fail here instead, with
 # a message that points at the actual problem.
-ifeq ($(shell pkg-config --exists talloc && echo yes),)
+ifeq ($(shell ${PKG_CONFIG} --exists talloc && echo yes),)
 $(error talloc development files not found by pkg-config. Install the \
 talloc headers package for your distribution (e.g. libtalloc-dev on \
 Debian/Ubuntu, libtalloc-devel on Fedora/RHEL/CentOS) and make sure \
@@ -36,16 +37,16 @@ pkg-config can find talloc.pc (check the PKG_CONFIG_PATH environment \
 variable if it's installed in a non-standard location))
 endif
 
-CFLAGS   += $(shell pkg-config --cflags talloc)
+CFLAGS   += $(shell ${PKG_CONFIG} --cflags talloc)
 LDFLAGS  += -Wl,-z,noexecstack
-LDFLAGS  += $(shell pkg-config --libs talloc)
+LDFLAGS  += $(shell ${PKG_CONFIG} --libs talloc)
 
 ifneq ($(findstring -static,$(LDFLAGS)),)
-CARE_LDFLAGS  = -Wl,--start-group $(shell pkg-config --libs --static libarchive) \
-                $(shell pkg-config --exists libxml-2.0 && pkg-config --libs --static libxml-2.0) \
+CARE_LDFLAGS  = -Wl,--start-group $(shell ${PKG_CONFIG} --libs --static libarchive) \
+                $(shell ${PKG_CONFIG} --exists libxml-2.0 && ${PKG_CONFIG} --libs --static libxml-2.0) \
                 -lm -lstdc++ -Wl,--end-group
 else
-CARE_LDFLAGS  = $(shell pkg-config --libs libarchive)
+CARE_LDFLAGS  = $(shell ${PKG_CONFIG} --libs libarchive)
 endif
 
 OBJECTS += \
@@ -179,7 +180,7 @@ build.h: $(CHECK_RESULTS)
 	$(Q)cat $^                      >> $@
 	$(Q)echo "#endif /* BUILD_H */" >> $@
 
-BUILD_ID_NONE := $(shell if ld --build-id=none --version >/dev/null 2>&1; then echo ',--build-id=none'; fi)
+BUILD_ID_NONE := $(shell if ${LD_CMD} --build-id=none --version >/dev/null 2>&1; then echo ',--build-id=none'; fi)
 
 ######################################################################
 # Build rules

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -24,6 +24,7 @@ HAS_PYTHON_CONFIG := $(shell ${PYTHON}-config --ldflags ${PYTHON_EMBED} 2>/dev/n
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../lib/uthash/include
 CFLAGS   += -g -Wall -Wextra -O2
+
 # pkg-config silently returns an empty string for --cflags/--libs when it
 # can't find talloc.pc, which used to surface much later and much more
 # confusingly as "undefined reference to talloc_*" at link time (see


### PR DESCRIPTION
## Why

#359: every other tool the Makefile invokes (`CC`, `STRIP`, `OBJCOPY`, `OBJDUMP`) respects `$(CROSS_COMPILE)`, but `pkg-config` and `ld` don't. They're hardcoded to the host's versions. That silently breaks cross-compilation, since the host `pkg-config` resolves the host's `talloc`/`libarchive` `.pc` files instead of the target's.

Prerequisite for the upcoming multi-arch work (powerpc64/MIPS/s390x, milestone #14). Those ports will lean on cross-compilation rather than only native builds under QEMU.

## What this does

Cherry-picked from #361 (credited to Shuhei Takahashi, @nya3jp), with authorship preserved. It's the more complete of the two existing open PRs on this; #403 is pkg-config-only, #361 also fixes `ld` for the `BUILD_ID_NONE` probe. Adds `PKG_CONFIG`/`LD_CMD` variables derived from `$(CROSS_COMPILE)`, reconciled with the `CARE_LDFLAGS` static-linking logic and the talloc pkg-config existence check added since #361 was opened (same lines, needed a real merge, not just a rebase).

Closes #359, #361, and #403 (superseded, folded into this).

## Verification

Confirmed two things separately, both in Docker.

Native build is unaffected. `make -C src clean loader.elf build.h proot` (no `CROSS_COMPILE`) still builds and runs correctly.

Cross-compilation actually works now. Installed `crossbuild-essential-arm64` plus `libarchive-dev:arm64`/`libtalloc-dev:arm64` on an amd64 Ubuntu 24.04 container (via `ports.ubuntu.com`, since foreign architectures aren't on the default mirrors), confirmed `aarch64-linux-gnu-pkg-config --libs talloc` resolves the arm64 `talloc.pc` and not the host's, then ran `make -C src clean loader.elf build.h proot CROSS_COMPILE=aarch64-linux-gnu-` end to end. Result: `src/proot: ELF 64-bit LSB pie executable, ARM aarch64, ... dynamically linked, interpreter /lib/ld-linux-aarch64.so.1`, a genuine cross-built ARM64 binary produced entirely from an amd64 host.

## Next

Part 1 of 3 in fixing the build system before the multi-arch work starts. This is part 1. Part 2 fixes the silent HAS_SWIG/HAS_PYTHON_CONFIG feature-detection pattern that broke `release.yml` twice during v5.4.1. Part 3 adds a cross-compile CI smoke test.
