### PR TITLE
fix(build): add WITHOUT_PYTHON to explicitly disable the python extension

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,15 @@ jobs:
 
       - name: Build static proot and care binaries
         run: |
-          # HAS_SWIG/HAS_PYTHON_CONFIG override: swig and python3-config
-          # are preinstalled on GitHub's ubuntu-latest runners regardless
-          # of what this workflow apt-get installs, which silently
-          # re-enables proot's optional Python extension. Its static
-          # dependencies (Ubuntu's libpython3.a) don't resolve under
-          # -static, so force it off explicitly rather than relying on
-          # the tools being absent. Must be passed to both invocations:
-          # build.h bakes in HAVE_PYTHON_EXTENSION from the first one.
-          make -C src clean loader.elf loader-m32.elf build.h HAS_SWIG= HAS_PYTHON_CONFIG=
-          LDFLAGS="${LDFLAGS} -static" make -C src proot care HAS_SWIG= HAS_PYTHON_CONFIG=
+          # WITHOUT_PYTHON=1: swig and python3-config are preinstalled on
+          # GitHub's ubuntu-latest runners regardless of what this workflow
+          # apt-get installs, which would otherwise silently re-enable
+          # proot's optional Python extension. Its static dependencies
+          # (Ubuntu's libpython3.a) don't resolve under -static. Must be
+          # passed to both invocations: build.h bakes in
+          # HAVE_PYTHON_EXTENSION from the first one.
+          make -C src clean loader.elf loader-m32.elf build.h WITHOUT_PYTHON=1
+          LDFLAGS="${LDFLAGS} -static" make -C src proot care WITHOUT_PYTHON=1
 
       - name: Verify the embedded version string matches the tag
         run: |

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -15,10 +15,28 @@ OBJCOPY  = $(CROSS_COMPILE)objcopy
 OBJDUMP  = $(CROSS_COMPILE)objdump
 PYTHON   = python3
 
-HAS_SWIG := $(shell swig -version 2>/dev/null)
 PYTHON_MAJOR_VERSION = $(shell ${PYTHON} -c "import sys; print(sys.version_info.major)" 2>/dev/null)
 PYTHON_EMBED = $(shell ${PYTHON} -c "import sys; print('--embed' if sys.hexversion > 0x03080000 else '')" 2>/dev/null)
+
+# The python extension is built whenever both swig and python3-config
+# are found on PATH -- which makes "is it available" and "is it wanted"
+# the same question, and that's the wrong question to ask on a build
+# image that happens to have a full Python toolchain preinstalled for
+# unrelated reasons (e.g. GitHub's ubuntu-latest runners: both are
+# present there by default, regardless of what this Makefile's own
+# caller apt-get installs). That silently re-enabled the extension in
+# release.yml's static build and broke it, since Ubuntu's static
+# libpython doesn't resolve all its own symbols under -static.
+#
+# WITHOUT_PYTHON=1 makes the "don't want it" case explicit instead of
+# relying on the tools happening to be absent.
+ifneq ($(WITHOUT_PYTHON),)
+HAS_SWIG :=
+HAS_PYTHON_CONFIG :=
+else
+HAS_SWIG := $(shell swig -version 2>/dev/null)
 HAS_PYTHON_CONFIG := $(shell ${PYTHON}-config --ldflags ${PYTHON_EMBED} 2>/dev/null)
+endif
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../lib/uthash/include
 CFLAGS   += -g -Wall -Wextra -O2


### PR DESCRIPTION
## Why

The python extension is built whenever both `swig` and `python3-config` are found on `PATH`. That makes "is it available" and "is it wanted" the same question, and that's the wrong question to ask on a build image with a full Python toolchain preinstalled for unrelated reasons. GitHub's `ubuntu-latest` runners have both regardless of what a workflow's own `apt-get install` list contains. This silently re-enabled proot's optional Python extension in `release.yml`'s static build and broke it twice, since Ubuntu's static `libpython3.a` doesn't resolve all its own symbols under `-static`. The workaround was passing `HAS_SWIG= HAS_PYTHON_CONFIG=` on the command line, which works but isn't discoverable. You'd have to already know those are the two internal detection variables.

Part 2 of 3 in fixing the build system before the multi-arch work starts (part 1: #430).

## What this does

Adds `WITHOUT_PYTHON=1` as an explicit, documented override. Default behavior (auto-detect via `swig -version`/`python3-config`) is unchanged. `release.yml` now uses the flag in place of the `HAS_SWIG=`/`HAS_PYTHON_CONFIG=` workaround.

## Verification

Both done in Docker with `swig` and `python3-config` genuinely installed, matching the real runner, not just their absence.

Default, no flag: `build.h` still gets `#define HAVE_PYTHON_EXTENSION`. Unchanged behavior confirmed.

`WITHOUT_PYTHON=1`: extension correctly skipped, and the full static release build (both `make` invocations, matching `release.yml` exactly: `build.h` generation, then `LDFLAGS=-static make proot care`) succeeds end to end. Both `proot` and `care` come out fully static (`not a dynamic executable`), and `proot --version` prints correctly.
