### PR TITLE
ci: add a cross-compile smoke test (aarch64)

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,3 +43,39 @@ jobs:
         if: always()
         continue-on-error: true
         run: ([ -f test.log ] && cat test.log) || true
+
+  cross-compile:
+    name: cross-compile (aarch64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Add the arm64 architecture and its package sources
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo tee /etc/apt/sources.list.d/arm64-ports.list > /dev/null <<'EOF'
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe
+          EOF
+          # archive.ubuntu.com/security.ubuntu.com don't carry foreign
+          # architectures; scope the default sources to amd64 so apt
+          # doesn't try to fetch arm64 packages from them.
+          sudo sed -i '/^Signed-By:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update -qq
+
+      - name: Install cross toolchain and target libraries
+        run: |
+          sudo apt-get install -qq -y crossbuild-essential-arm64 pkg-config uthash-dev qemu-user \
+            libarchive-dev:arm64 libtalloc-dev:arm64
+
+      - name: Cross-build proot and care for aarch64
+        run: |
+          make -C src clean loader.elf build.h proot care CROSS_COMPILE=aarch64-linux-gnu- WITHOUT_PYTHON=1
+
+      - name: Verify the cross-built binary is a real aarch64 ELF and actually runs
+        run: |
+          file src/proot | grep -q 'ARM aarch64' || { echo "::error::src/proot is not an aarch64 binary"; exit 1; }
+          qemu-aarch64 -L /usr/aarch64-linux-gnu src/proot --version | head -3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,16 +41,15 @@ jobs:
 
       - name: Build static proot and care binaries
         run: |
-          # HAS_SWIG/HAS_PYTHON_CONFIG override: swig and python3-config
-          # are preinstalled on GitHub's ubuntu-latest runners regardless
-          # of what this workflow apt-get installs, which silently
-          # re-enables proot's optional Python extension. Its static
-          # dependencies (Ubuntu's libpython3.a) don't resolve under
-          # -static, so force it off explicitly rather than relying on
-          # the tools being absent. Must be passed to both invocations:
-          # build.h bakes in HAVE_PYTHON_EXTENSION from the first one.
-          make -C src clean loader.elf loader-m32.elf build.h HAS_SWIG= HAS_PYTHON_CONFIG=
-          LDFLAGS="${LDFLAGS} -static" make -C src proot care HAS_SWIG= HAS_PYTHON_CONFIG=
+          # WITHOUT_PYTHON=1: swig and python3-config are preinstalled on
+          # GitHub's ubuntu-latest runners regardless of what this workflow
+          # apt-get installs, which would otherwise silently re-enable
+          # proot's optional Python extension. Its static dependencies
+          # (Ubuntu's libpython3.a) don't resolve under -static. Must be
+          # passed to both invocations: build.h bakes in
+          # HAVE_PYTHON_EXTENSION from the first one.
+          make -C src clean loader.elf loader-m32.elf build.h WITHOUT_PYTHON=1
+          LDFLAGS="${LDFLAGS} -static" make -C src proot care WITHOUT_PYTHON=1
 
       - name: Verify the embedded version string matches the tag
         run: |

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -15,10 +15,28 @@ OBJCOPY  = $(CROSS_COMPILE)objcopy
 OBJDUMP  = $(CROSS_COMPILE)objdump
 PYTHON   = python3
 
-HAS_SWIG := $(shell swig -version 2>/dev/null)
 PYTHON_MAJOR_VERSION = $(shell ${PYTHON} -c "import sys; print(sys.version_info.major)" 2>/dev/null)
 PYTHON_EMBED = $(shell ${PYTHON} -c "import sys; print('--embed' if sys.hexversion > 0x03080000 else '')" 2>/dev/null)
+
+# The python extension is built whenever both swig and python3-config
+# are found on PATH -- which makes "is it available" and "is it wanted"
+# the same question, and that's the wrong question to ask on a build
+# image that happens to have a full Python toolchain preinstalled for
+# unrelated reasons (e.g. GitHub's ubuntu-latest runners: both are
+# present there by default, regardless of what this Makefile's own
+# caller apt-get installs). That silently re-enabled the extension in
+# release.yml's static build and broke it, since Ubuntu's static
+# libpython doesn't resolve all its own symbols under -static.
+#
+# WITHOUT_PYTHON=1 makes the "don't want it" case explicit instead of
+# relying on the tools happening to be absent.
+ifneq ($(WITHOUT_PYTHON),)
+HAS_SWIG :=
+HAS_PYTHON_CONFIG :=
+else
+HAS_SWIG := $(shell swig -version 2>/dev/null)
 HAS_PYTHON_CONFIG := $(shell ${PYTHON}-config --ldflags ${PYTHON_EMBED} 2>/dev/null)
+endif
 
 CPPFLAGS += -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -I. -I$(VPATH) -I$(VPATH)/../lib/uthash/include
 CFLAGS   += -g -Wall -Wextra -O2


### PR DESCRIPTION
## Why

Nothing in CI actually exercised `CROSS_COMPILE` before this. #430 fixed `pkg-config`/`ld` to respect it, but nothing proved the whole chain works end to end, or would catch a regression if it broke again.

Part 3 of 3 in fixing the build system before the multi-arch work starts (part 1: #430, part 2: #431).

**Depends on both #430 and #431**, not just #430: the smoke test needs `WITHOUT_PYTHON=1` (from #431) to avoid picking up the host's preinstalled Python for what should be a target-arch build (`PYTHON` is never `$(CROSS_COMPILE)`-prefixed, so an unprefixed `python3-config` is always wrong for a cross build regardless). Branch now includes both. Merge order: #430, then #431, then this.

## What this does

New `cross-compile` job in `pull-request.yml`. Adds the arm64 architecture and `ports.ubuntu.com` as its package source (foreign architectures aren't on the default amd64 mirrors), installs `crossbuild-essential-arm64` plus arm64 `libarchive-dev`/`libtalloc-dev`, then cross-builds `proot`/`care` with `CROSS_COMPILE=aarch64-linux-gnu- WITHOUT_PYTHON=1`. Verification isn't just "it links": `file` confirms a real aarch64 ELF, then `qemu-user` actually runs the resulting binary and checks `--version` output.

## Verification

First attempt at this actually caught a real bug: I'd based this branch on #430 alone, so `WITHOUT_PYTHON=1` was silently a no-op (that flag didn't exist yet on this branch), and real CI failed trying to compile the Python extension against the runner's host `python3.12` headers for an aarch64 target. My own local Docker verification had missed it too, for the same reason release.yml broke twice: I hadn't installed `python3-dev`/`swig` in that test container, so the absence of the tools was doing the work, not the flag.

Fixed by merging in #431's branch, then rerunning the exact same verification with `python3-dev` and `swig` genuinely installed this time (matching the real runner, not just their absence): cross-build succeeds, `file src/proot` confirms `ARM aarch64`, and `qemu-aarch64 -L /usr/aarch64-linux-gnu src/proot --version` actually executes the cross-built binary and prints its version banner.