### PR TITLE
ci: enable tests in Ubuntu 26.04

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,12 +9,15 @@ on:
 
 jobs:
   build:
-    name: "${{ matrix.SECCOMP == '1' && 'seccomp' || 'no-seccomp' }}"
-    runs-on: ubuntu-latest
+    name: "${{ matrix.SECCOMP == '1' && 'seccomp' || 'no-seccomp' }} | ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    env:
+      BUILD_WRAPPER_OUT_DIR: tmp
     strategy:
       fail-fast: false
       matrix:
         SECCOMP: [ 0, 1 ]
+        os: [ubuntu-24.04, ubuntu-26.04]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3


### PR DESCRIPTION
## Why

Cherry-picked from #416 (credited to Alexander Sherikov, @asherikov), with authorship preserved. Tests only ran on `ubuntu-24.04` before this; Ubuntu 26.04 is out now and worth catching regressions on early.

## What this does

Adds `ubuntu-26.04` as a second `os` matrix dimension alongside the existing `SECCOMP` matrix, so both build jobs now run on both OS versions.

One thing dropped from the original PR: it also added `#include "tracee/mem.h"` to `src/tracee/tracee.c` to fix a build failure the author hit on Ubuntu 26. Turns out `master` already has that include (added independently since #416 was opened), so re-applying it verbatim during the cherry-pick produced a duplicate include. Removed the duplicate; nothing left to carry over there since the underlying problem's already fixed.

## Verification

Conflict was only in `.github/workflows/pull-request.yml` (expected — `master` gained a new `cross-compile` job and a `pkg-config` dependency since #416 was opened); resolved by hand, keeping both sides' additions. Confirmed `tracee.c` now matches `master` exactly (no net change, since the include it wanted to add is already there). Real proof is CI actually running the `ubuntu-26.04` matrix legs on this PR.

fixes: https://github.com/proot-me/proot/issues/416