### PR TITLE
fix: cherry-pick cross-compile (aarch64) job to master

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -43,3 +43,39 @@ jobs:
         if: always()
         continue-on-error: true
         run: ([ -f test.log ] && cat test.log) || true
+
+  cross-compile:
+    name: cross-compile (aarch64)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v3
+        with:
+          fetch-depth: 0
+
+      - name: Add the arm64 architecture and its package sources
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo tee /etc/apt/sources.list.d/arm64-ports.list > /dev/null <<'EOF'
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe
+          EOF
+          # archive.ubuntu.com/security.ubuntu.com don't carry foreign
+          # architectures; scope the default sources to amd64 so apt
+          # doesn't try to fetch arm64 packages from them.
+          sudo sed -i '/^Signed-By:/a Architectures: amd64' /etc/apt/sources.list.d/ubuntu.sources
+          sudo apt-get update -qq
+
+      - name: Install cross toolchain and target libraries
+        run: |
+          sudo apt-get install -qq -y crossbuild-essential-arm64 pkg-config uthash-dev qemu-user \
+            libarchive-dev:arm64 libtalloc-dev:arm64
+
+      - name: Cross-build proot and care for aarch64
+        run: |
+          make -C src clean loader.elf build.h proot care CROSS_COMPILE=aarch64-linux-gnu- WITHOUT_PYTHON=1
+
+      - name: Verify the cross-built binary is a real aarch64 ELF and actually runs
+        run: |
+          file src/proot | grep -q 'ARM aarch64' || { echo "::error::src/proot is not an aarch64 binary"; exit 1; }
+          qemu-aarch64 -L /usr/aarch64-linux-gnu src/proot --version | head -3


### PR DESCRIPTION
## Why

While working on #416, found that #432's actual `cross-compile (aarch64)` job never made it to `master`, despite showing as "Merged" on GitHub.

#432 was a stacked PR based on `fix-cross-compile-pkgconfig-ld` (#430's branch), not `master` directly, deliberately, so its diff only showed the new job. #430 merged into `master` first. #432 then merged its commit into the now-stale `fix-cross-compile-pkgconfig-ld` branch, not `master` — and since that branch had already been merged once via #430, nothing carried the new commit over afterward. `gh pr view 432` correctly reports `MERGED`, but that only describes #432's own merge target, not where the content ended up.

Confirmed directly: `master` is missing the `cross-compile` job entirely, and diffing #432's actual head commit against current `master` shows exactly one 36-line addition (the job itself) as the only difference.

## What this does

Cherry-picks `9041c07` (the actual job-adding commit) directly onto `master`. No conflicts, since `master` didn't have any of this content.

## Verification

Diffed #432's head against `master` before cherry-picking to confirm the job was the *only* thing missing (not a partial/parallel divergence). Real proof is this job actually running (and passing) in CI on this PR — same job, same recipe already verified working when #432 itself was open.